### PR TITLE
Fixes existing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 npm-debug.log
 npm-debug.log.*
+.DS_Store

--- a/lib/components/fields/shared.mcss
+++ b/lib/components/fields/shared.mcss
@@ -1,4 +1,3 @@
 .base {
   margin-bottom: 1.6em;
 }
-

--- a/lib/components/group.js
+++ b/lib/components/group.js
@@ -17,6 +17,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var Group = _react2.default.createClass({
   displayName: 'Group',
+
+
+  propTypes: {
+    hashCode: _react2.default.PropTypes.array,
+    children: _react2.default.PropTypes.array
+  },
+
   shouldComponentUpdate: function shouldComponentUpdate(nextProps) {
     // Use the path hash-code to determine whether or not to rerender this
     // section. This should take account of any change to the AST.

--- a/lib/components/many.js
+++ b/lib/components/many.js
@@ -13,6 +13,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var ManySet = _react2.default.createClass({
   displayName: 'ManySet',
+
+
+  propTypes: {
+    children: _react2.default.PropTypes.array
+  },
+
   render: function render() {
     return _react2.default.createElement(
       'div',
@@ -53,6 +59,12 @@ var Many = function Many(_ref) {
       );
     })
   );
+};
+
+Many.propTypes = {
+  name: _react2.default.PropTypes.string,
+  errors: _react2.default.PropTypes.array,
+  children: _react2.default.PropTypes.array
 };
 
 exports.default = Many;

--- a/lib/components/section.js
+++ b/lib/components/section.js
@@ -9,10 +9,6 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactImmutableProptypes = require('react-immutable-proptypes');
-
-var _reactImmutableProptypes2 = _interopRequireDefault(_reactImmutableProptypes);
-
 var _section = require('./section.mcss');
 
 var _section2 = _interopRequireDefault(_section);
@@ -21,6 +17,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var Section = _react2.default.createClass({
   displayName: 'Section',
+
+
+  propTypes: {
+    hashCode: _react2.default.PropTypes.string,
+    config: _react2.default.PropTypes.array,
+    name: _react2.default.PropTypes.string,
+    children: _react2.default.PropTypes.array
+  },
+
   shouldComponentUpdate: function shouldComponentUpdate(nextProps) {
     // Use the path hash-code to determine whether or not to rerender this
     // section. This should take account of any change to the AST.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "postcss-modules-scope": "^1.0.0",
     "postcss-modules-values": "^1.1.1",
     "react-day-picker": "^1.2.0",
-    "react-dom": "^0.14.6",
     "react-immutable-proptypes": "^1.5.1",
     "react-portal": "1.7.0",
     "react-textarea-autosize": "^3.3.0",
@@ -75,6 +74,7 @@
     "uid": "0.0.2"
   },
   "peerDependencies": {
-    "react": "^0.14.7"
+    "react": "^0.14.7",
+    "react-dom": "^0.14.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "homepage": "https://github.com/icelab/formalist-standard-react",
   "devDependencies": {
+    "@f/is-function": "^1.1.1",
+    "autoprefixer": "^6.3.3",
     "babel-cli": "^6.3.17",
     "babel-loader": "^6.2.1",
     "babel-plugin-css-modules-transform": "0.0.4",
@@ -45,6 +47,8 @@
     "eslint-plugin-react": "^3.13.1",
     "eslint-plugin-standard": "^1.3.1",
     "faucet": "0.0.1",
+    "ignore-styles": "^1.2.0",
+    "jsdom": "^8.0.4",
     "react-addons-test-utils": "^0.14.5",
     "tape": "^4.2.2",
     "wr": "^1.3.1"

--- a/src/components/fields/shared.mcss
+++ b/src/components/fields/shared.mcss
@@ -1,4 +1,3 @@
 .base {
   margin-bottom: 1.6em;
 }
-

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -3,6 +3,12 @@ import React from 'react'
 import styles from './group.mcss'
 
 const Group = React.createClass({
+
+  propTypes: {
+    hashCode: React.PropTypes.array,
+    children: React.PropTypes.array
+  },
+
   shouldComponentUpdate (nextProps) {
     // Use the path hash-code to determine whether or not to rerender this
     // section. This should take account of any change to the AST.

--- a/src/components/many.js
+++ b/src/components/many.js
@@ -1,6 +1,11 @@
 import React from 'react'
 
 const ManySet = React.createClass({
+
+  propTypes: {
+    children: React.PropTypes.array
+  },
+
   render () {
     return (
       <div>
@@ -22,6 +27,12 @@ const Many = ({name, children, errors}) => {
       ))}
     </div>
   )
+}
+
+Many.propTypes = {
+  name: React.PropTypes.string,
+  errors: React.PropTypes.array,
+  children: React.PropTypes.array
 }
 
 export default Many

--- a/src/components/section.js
+++ b/src/components/section.js
@@ -1,8 +1,15 @@
 import React from 'react'
-import ImmutablePropTypes from 'react-immutable-proptypes'
 import styles from './section.mcss'
 
 const Section = React.createClass({
+
+  propTypes: {
+    hashCode: React.PropTypes.string,
+    config: React.PropTypes.array,
+    name: React.PropTypes.string,
+    children: React.PropTypes.array
+  },
+
   shouldComponentUpdate (nextProps) {
     // Use the path hash-code to determine whether or not to rerender this
     // section. This should take account of any change to the AST.

--- a/test/fixtures/data-simple.js
+++ b/test/fixtures/data-simple.js
@@ -2,44 +2,48 @@ const simple = [
   [
     'field',
     [
-      'field_one_name',
+      'string_default',
       'string',
-      '123',
-      [
-        'error message one', 'error message two'
-      ],
-      [
-        ['label', 'Field one name'],
-        ['display_variant', 'select'],
-        ['option_values', [
-          ['123', '123'], ['234', '234'], ['456', '456']
-        ]]
-      ]
+      'default',
+      null,
+      [],
+      [],
+      []
     ]
   ],
   [
     'field',
     [
-      'field_two_name',
+      'string_code',
       'string',
-      'Title goes here',
+      'default',
+      null,
+      [],
       [],
       [
-        ['display_options', ['code']]
+        [
+          'display_options',
+          [
+            'code'
+          ]
+        ]
       ]
     ]
   ],
   [
     'section',
     [
-      'Main section',
+      'string',
+      [],
       [
         [
           'field',
           [
-            'field_three_name',
+            'string_default',
             'string',
-            '321',
+            'default',
+            null,
+            [],
             [],
             []
           ]
@@ -47,9 +51,11 @@ const simple = [
         [
           'field',
           [
-            'field_four_name',
+            'string_password',
             'string',
-            'Content goes here',
+            'default',
+            null,
+            [],
             [],
             []
           ]
@@ -60,118 +66,181 @@ const simple = [
   [
     'field',
     [
-      'field_int_name',
+      'int_step',
       'int',
-      123,
+      'default',
+      null,
+      [],
       [],
       [
-        ['step', 2]
+        [
+          'step',
+          5
+        ]
       ]
     ]
   ],
   [
     'field',
     [
-      'field_int_as_select',
-      'int',
-      5,
-      [],
-      [
-        ['display_variant', 'select'],
-        ['option_values', [
-          [1, 'Top right'],
-          [2, 'Top center'],
-          [3, 'Top right'],
-          [4, 'Middle right'],
-          [5, 'Middle center'],
-          [6, 'Middle right'],
-          [7, 'Bottom right'],
-          [8, 'Bottom center'],
-          [9, 'Bottom right']
-        ]]
-      ]
-    ]
-  ],
-  [
-    'field',
-    [
-      'field_string_as_radio',
+      'string_select',
       'string',
-      'left',
+      'select',
+      null,
+      [],
       [],
       [
-        ['display_variant', 'radio'],
-        ['option_values', [
-          ['left', 'Left'], ['right', 'Right']
-        ]]
+        [
+          'label',
+          'String (select)'
+        ],
+        [
+          'placeholder',
+          'Select your favourite number'
+        ],
+        [
+          'option_values',
+          [
+            'One',
+            'Two',
+            'Three'
+          ]
+        ]
       ]
     ]
   ],
   [
     'field',
     [
-      'field_int_as_radio',
+      'string_radio',
+      'string',
+      'radio',
+      null,
+      [],
+      [],
+      [
+        [
+          'label',
+          'String (radio)'
+        ],
+        [
+          'option_values',
+          [
+            'One',
+            'Two',
+            'Three'
+          ]
+        ]
+      ]
+    ]
+  ],
+  [
+    'field',
+    [
+      'int_radio',
       'int',
-      5,
+      'radio',
+      null,
+      [],
       [],
       [
-        ['display_variant', 'radio'],
-        ['option_values', [
-          [1, 'Top right'],
-          [2, 'Top center'],
-          [3, 'Top right'],
-          [4, 'Middle right'],
-          [5, 'Middle center'],
-          [6, 'Middle right'],
-          [7, 'Bottom right'],
-          [8, 'Bottom center'],
-          [9, 'Bottom right']
-        ]]
+        [
+          'label',
+          'Int (radio)'
+        ],
+        [
+          'option_values',
+          [
+            [
+              1,
+              'One'
+            ],
+            [
+              2,
+              'Two'
+            ],
+            [
+              3,
+              'Three'
+            ]
+          ]
+        ]
       ]
     ]
   ],
   [
     'field',
     [
-      'field_float_as_radio',
+      'float_radio',
       'float',
-      0.5,
+      'radio',
+      null,
+      [],
       [],
       [
-        ['display_variant', 'radio'],
-        ['option_values', [
-          [0.1, 'Top right'],
-          [0.2, 'Top center'],
-          [0.3, 'Top right'],
-          [0.4, 'Middle right'],
-          [0.5, 'Middle center'],
-          [0.6, 'Middle right'],
-          [0.7, 'Bottom right'],
-          [0.8, 'Bottom center'],
-          [0.9, 'Bottom right']
-        ]]
+        [
+          'label',
+          'Float (radio)'
+        ],
+        [
+          'option_values',
+          [
+            [
+              1.1,
+              '1.1'
+            ],
+            [
+              2.4,
+              '2.4'
+            ],
+            [
+              3.14159265359,
+              'Ï€'
+            ]
+          ]
+        ]
       ]
     ]
   ],
   [
     'field',
     [
-      'field_decimal',
+      'decimal_default',
       'decimal',
-      5.5,
+      'default',
+      null,
       [],
-      []
+      [],
+      [
+        [
+          'label',
+          'Decimal (default)'
+        ],
+        [
+          'placeholder',
+          'Default decimal input'
+        ]
+      ]
     ]
   ],
   [
     'field',
     [
-      'field_bool',
+      'bool_default',
       'bool',
-      false,
+      'default',
+      null,
+      [],
       [],
       [
-        ['question_text', 'Is boolean?']
+        [
+          'label',
+          'Bool (default)'
+        ],
+        [
+          'question_text',
+          'Do you like me?'
+        ]
       ]
     ]
   ]

--- a/test/fixtures/dom.js
+++ b/test/fixtures/dom.js
@@ -1,0 +1,12 @@
+import jsdom from 'jsdom'
+
+// A super simple DOM ready for React to render into
+// Store this DOM and the window in global scope ready for React to access
+
+export default function createDOM () {
+  global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
+  global.window = document.defaultView
+  global.navigator = { userAgent: 'node.js' }
+}
+
+createDOM()

--- a/test/fixtures/ignore-styles.js
+++ b/test/fixtures/ignore-styles.js
@@ -1,0 +1,34 @@
+const DEFAULT_EXTENSIONS = [
+  '.mcss',
+  '.css',
+  '.scss',
+  '.sass',
+  '.stylus',
+  '.styl',
+  '.less'
+]
+
+let oldHandlers = {}
+
+function noOp () {}
+
+function restore () {
+  for (const ext in oldHandlers) {
+    if (oldHandlers[ext] === undefined) {
+      delete require.extensions[ext]
+    } else {
+      require.extensions[ext] = oldHandlers[ext]
+    }
+  }
+}
+
+export default function register (extensions = DEFAULT_EXTENSIONS, handler = noOp) {
+  restore()
+
+  for (const ext of extensions) {
+    oldHandlers[ext] = require.extensions[ext]
+    require.extensions[ext] = handler
+  }
+}
+
+register()

--- a/test/index.js
+++ b/test/index.js
@@ -1,21 +1,14 @@
 import test from 'tape'
 import { mount } from 'enzyme'
 import React from 'react'
-import jsdom from 'jsdom'
+import isFunction from '@f/is-function'
 
-// A super simple DOM ready for React to render into
-// Store this DOM and the window in global scope ready for React to access
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
-global.window = document.defaultView
-global.navigator = {userAgent: 'node.js'}
-
-// import { actionTypes } from 'formalist-compose'
+/* fixtures */
+import './fixtures/ignore-styles'
+import './fixtures/dom'
 import dataSimple from './fixtures/data-simple'
-import standardFormTemplate from '../src'
 
-const isFunction = function (obj) {
-  return typeof obj === 'function'
-}
+import standardFormTemplate from '../src'
 
 test('it should export a standard form template', (nest) => {
   nest.test('... returning a callable function', (assert) => {
@@ -29,20 +22,21 @@ test('it should create a standard form instance', (nest) => {
   let wrapper = mount(<article>{form.render()}</article>)
 
   nest.test('... with different display types for inputs', (assert) => {
-    assert.ok(wrapper.find('input').at(0).hasClass('fm-field-string--code'))
+    const el = wrapper.find('input').at(0).node
+    const actual = el.getAttribute('id')
+    const expected = 'string_default'
+    assert.equal(expected, actual)
     assert.end()
   })
 
   nest.test('... that updates data', (assert) => {
-    assert.plan(1)
-
-    let expectedValue = 'Data has changed'
+    let expected = 'Data has changed'
     let input = wrapper.find('input').at(0)
-    wrapper.find('input').get(0).value = expectedValue
+    wrapper.find('input').get(0).value = expected
 
     form.store.subscribe(() => {
-      let updatedValue = form.store.getState().getIn([1, 1, 2])
-      assert.equals(updatedValue, expectedValue)
+      let actual = form.store.getState().getIn([0, 1, 3])
+      assert.equals(expected, actual)
       assert.end()
     })
 


### PR DESCRIPTION
This PR fixes existing tests.

The extension `.mcss` for styles is retained. The tests no rely on a local module (local to `tests`) to ignore importing styles. It was easier to turn this into a local module that fires when we want it (immediately) with a list of extensions we can easily maintain.

The `simple-data.js` structure was also updated.