### PR TITLE
Add a `Popout` component.

### DIFF
--- a/lib/components/ui/popout/index.js
+++ b/lib/components/ui/popout/index.js
@@ -1,6 +1,226 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = {};
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactPortal = require('react-portal');
+
+var _reactPortal2 = _interopRequireDefault(_reactPortal);
+
+var _popout = require('./popout.mcss');
+
+var _popout2 = _interopRequireDefault(_popout);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var arrowVertPosition = 16;
+
+/**
+ * A "popout" component. Creates a element that pops over the passed
+ * `reference` element.
+ *
+ * The reference element is the node that the popout takes its position from
+ * it’s expected that this is the _first_ element in `props.children`.
+ *
+ * All other children are assumed to be part of the content of the underhanging
+ * `container` and will be rendered there in order. The `container` is rendered
+ * into a `Portal`, which an element that’s appended to the `<body>` to avoid
+ * any DOM flow complications.
+ *
+ * Takes an `props.offset {top, left}` to adjust position
+ *
+ * Exposes:
+ *
+ * @method calculatePosition
+ * @method openPopout
+ * @method closePopout
+ * @method getContainer
+ */
+var Popout = _react2.default.createClass({
+  displayName: 'Popout',
+
+
+  propTypes: {
+    beforeClose: _react2.default.PropTypes.func,
+    children: _react2.default.PropTypes.node,
+    closeOnEsc: _react2.default.PropTypes.bool,
+    closeOnOutsideClick: _react2.default.PropTypes.bool,
+    offset: _react2.default.PropTypes.shape({
+      default: _react2.default.PropTypes.number,
+      vert: _react2.default.PropTypes.number,
+      horz: _react2.default.PropTypes.number
+    }),
+    openByClickOn: _react2.default.PropTypes.node,
+    onOpen: _react2.default.PropTypes.func,
+    onClose: _react2.default.PropTypes.func,
+    onUpdate: _react2.default.PropTypes.func
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      placement: 'right',
+      offset: {
+        default: 10
+      }
+    };
+  },
+  getInitialState: function getInitialState() {
+    return {
+      position: {
+        left: 0,
+        top: 0
+      }
+    };
+  },
+  componentDidMount: function componentDidMount() {
+    this.calculatePosition();
+  },
+  componentWillMount: function componentWillMount() {
+    window.addEventListener('resize', this.onResize);
+  },
+  componentWillUnmount: function componentWillUnmount() {
+    window.removeEventListener('resize', this.onResize);
+  },
+
+
+  /**
+   * Public interface: Calculate the position of the popout wrapper
+   * @return {Object} Updated position we're setting
+   */
+  calculatePosition: function calculatePosition() {
+    // Only bother if its rendered
+    var position = undefined;
+    var placement = this.props.placement;
+
+    var referencePosition = this.refs.reference.getBoundingClientRect();
+    var horzOffset = this.props.offset.horz;
+    var vertOffset = this.props.offset.vert;
+    if (placement === 'left') {
+      horzOffset = horzOffset || this.props.offset.default;
+      vertOffset = vertOffset || 0;
+      position = {
+        left: referencePosition.left - horzOffset,
+        top: referencePosition.top + vertOffset + (referencePosition.height / 2 - arrowVertPosition)
+      };
+    } else if (placement === 'right') {
+      horzOffset = horzOffset || this.props.offset.default;
+      vertOffset = vertOffset || 0;
+      position = {
+        left: referencePosition.left + referencePosition.width + horzOffset,
+        top: referencePosition.top + vertOffset + (referencePosition.height / 2 - arrowVertPosition)
+      };
+    } else if (placement === 'top') {
+      horzOffset = horzOffset || 0;
+      vertOffset = vertOffset || this.props.offset.default;
+      position = {
+        left: referencePosition.left + referencePosition.width / 2 + horzOffset,
+        top: referencePosition.top - vertOffset
+      };
+    } else if (placement === 'bottom') {
+      horzOffset = horzOffset || 0;
+      vertOffset = vertOffset || this.props.offset.default;
+      position = {
+        left: referencePosition.left + referencePosition.width / 2 + horzOffset,
+        top: referencePosition.top + referencePosition.height + vertOffset
+      };
+    }
+
+    this.setState({
+      position: position
+    });
+    return position;
+  },
+
+
+  /**
+   * Public interface: Opens the `Portal`
+   */
+  openPopout: function openPopout() {
+    this.calculatePosition();
+    return this.refs.portal.openPortal();
+  },
+
+
+  /**
+   * Public: Close the `Portal`
+   */
+  closePopout: function closePopout() {
+    return this.refs.portal.closePortal();
+  },
+
+
+  /**
+   * Return the `container` node
+   */
+  getContainer: function getContainer() {
+    return this.refs.container;
+  },
+  onResize: function onResize(e) {
+    this.calculatePosition();
+  },
+  render: function render() {
+    // Extract Portal props
+    var _props = this.props;
+    var closeOnEsc = _props.closeOnEsc;
+    var closeOnOutsideClick = _props.closeOnOutsideClick;
+    var openByClickOn = _props.openByClickOn;
+    var onOpen = _props.onOpen;
+    var beforeClose = _props.beforeClose;
+    var onClose = _props.onClose;
+    var onUpdate = _props.onUpdate;
+    var placement = this.props.placement;
+    var position = this.state.position;
+
+    // Extract the reference element
+    // AKA child.first
+
+    var children = _react2.default.Children.toArray(this.props.children);
+    var reference = children[0];
+
+    var containerClassNames = (0, _classnames2.default)(_popout2.default.container, ['' + _popout2.default['container--' + placement]]);
+    var arrowClassNames = (0, _classnames2.default)(_popout2.default.containerArrow, ['' + _popout2.default['containerArrow--' + placement]]);
+
+    return _react2.default.createElement(
+      'div',
+      null,
+      _react2.default.createElement(
+        'div',
+        { ref: 'reference' },
+        reference
+      ),
+      _react2.default.createElement(
+        _reactPortal2.default,
+        {
+          ref: 'portal',
+          closeOnEsc: closeOnEsc,
+          closeOnOutsideClick: closeOnOutsideClick,
+          openByClickOn: openByClickOn,
+          onOpen: onOpen,
+          beforeClose: beforeClose,
+          onClose: onClose,
+          onUpdate: onUpdate },
+        _react2.default.createElement(
+          'div',
+          { className: _popout2.default.positioner, style: position },
+          _react2.default.createElement('div', { className: arrowClassNames }),
+          _react2.default.createElement(
+            'div',
+            { ref: 'container', className: containerClassNames },
+            children.slice(1)
+          )
+        )
+      )
+    );
+  }
+});
+
+exports.default = Popout;

--- a/lib/components/ui/popout/popout.mcss
+++ b/lib/components/ui/popout/popout.mcss
@@ -1,0 +1,125 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value popovers: '../popovers.mcss';
+@value greyLight, white from styles;
+
+.positioner {
+  position: absolute;
+  height: 0;
+  width: 0;
+}
+
+.container {
+  composes: normal sans whiteBackground from styles;
+  composes: popover from popovers;
+  border-radius: 3px;
+  max-height: 40rem;
+  max-width: 100vh;
+  min-height: 14rem;
+  min-width: 14rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  position: absolute;
+}
+
+.container--left {
+  right: 0;
+  top: 0;
+}
+
+.container--right {
+  left: 0;
+  top: 0;
+}
+
+.container--top {
+  bottom: 0;
+  left: 0;
+  transform: translateX(-50%);
+}
+
+.container--bottom {
+  top: 0;
+  left: 0;
+  transform: translateX(-50%);
+}
+
+/**
+ * Arrow is separate to avoid overflow issues
+ */
+.containerArrow {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+}
+  .containerArrow:after,
+  .containerArrow:before {
+    border-color: transparent;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+  }
+
+.containerArrow--left {
+  left: -1px;
+  top: 1.2rem;
+}
+  .containerArrow--left:before {
+    border-left-color: greyLight;
+    border-width: 6px;
+    margin-top: -1px;
+  }
+  .containerArrow--left:after {
+    border-left-color: white;
+    border-width: 5px;
+  }
+
+.containerArrow--right {
+  top: 1.2rem;
+  margin-left: -9px;
+}
+  .containerArrow--right:before {
+    border-right-color: greyLight;
+    border-width: 6px;
+    margin-left: -2px;
+    margin-top: -1px;
+  }
+  .containerArrow--right:after {
+    border-right-color: white;
+    border-width: 5px;
+  }
+.containerArrow--top {
+  margin-top: -1px;
+  left: 50%;
+  top: 100%;
+}
+  .containerArrow--top:before {
+    border-top-color: greyLight;
+    border-width: 6px;
+    margin-left: -6px;
+  }
+  .containerArrow--top:after {
+    border-top-color: white;
+    border-width: 5px;
+    margin-left: -5px;
+  }
+.containerArrow--bottom {
+  bottom: 100%;
+  left: 50%;
+  top: 1px;
+}
+  .containerArrow--bottom:before {
+    border-bottom-color: greyLight;
+    border-width: 6px;
+    margin-left: -6px;
+  }
+  .containerArrow--bottom:after {
+    border-bottom-color: white;
+    border-width: 5px;
+    margin-left: -5px;
+  }

--- a/src/components/ui/popout/index.js
+++ b/src/components/ui/popout/index.js
@@ -1,1 +1,205 @@
-export default {}
+import classNames from 'classnames'
+import React from 'react'
+import Portal from 'react-portal'
+import styles from './popout.mcss'
+
+const arrowVertPosition = 16
+
+/**
+ * A "popout" component. Creates a element that pops over the passed
+ * `reference` element.
+ *
+ * The reference element is the node that the popout takes its position from
+ * it’s expected that this is the _first_ element in `props.children`.
+ *
+ * All other children are assumed to be part of the content of the underhanging
+ * `container` and will be rendered there in order. The `container` is rendered
+ * into a `Portal`, which an element that’s appended to the `<body>` to avoid
+ * any DOM flow complications.
+ *
+ * Takes an `props.offset {top, left}` to adjust position
+ *
+ * Exposes:
+ *
+ * @method calculatePosition
+ * @method openPopout
+ * @method closePopout
+ * @method getContainer
+ */
+const Popout = React.createClass({
+
+  propTypes: {
+    beforeClose: React.PropTypes.func,
+    children: React.PropTypes.node,
+    closeOnEsc: React.PropTypes.bool,
+    closeOnOutsideClick: React.PropTypes.bool,
+    offset: React.PropTypes.shape({
+      default: React.PropTypes.number,
+      vert: React.PropTypes.number,
+      horz: React.PropTypes.number
+    }),
+    openByClickOn: React.PropTypes.node,
+    onOpen: React.PropTypes.func,
+    onClose: React.PropTypes.func,
+    onUpdate: React.PropTypes.func
+  },
+
+  getDefaultProps () {
+    return {
+      placement: 'right',
+      offset: {
+        default: 10
+      }
+    }
+  },
+
+  getInitialState () {
+    return {
+      position: {
+        left: 0,
+        top: 0
+      }
+    }
+  },
+
+  componentDidMount () {
+    this.calculatePosition()
+  },
+
+  componentWillMount () {
+    window.addEventListener('resize', this.onResize)
+  },
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.onResize)
+  },
+
+  /**
+   * Public interface: Calculate the position of the popout wrapper
+   * @return {Object} Updated position we're setting
+   */
+  calculatePosition () {
+    // Only bother if its rendered
+    let position
+    let { placement } = this.props
+    let referencePosition = this.refs.reference.getBoundingClientRect()
+    let horzOffset = this.props.offset.horz
+    let vertOffset = this.props.offset.vert
+    if (placement === 'left') {
+      horzOffset = horzOffset || this.props.offset.default
+      vertOffset = vertOffset || 0
+      position = {
+        left: referencePosition.left - horzOffset,
+        top: referencePosition.top + vertOffset + (referencePosition.height / 2 - arrowVertPosition)
+      }
+    } else if (placement === 'right') {
+      horzOffset = horzOffset || this.props.offset.default
+      vertOffset = vertOffset || 0
+      position = {
+        left: referencePosition.left + referencePosition.width + horzOffset,
+        top: referencePosition.top + vertOffset + (referencePosition.height / 2 - arrowVertPosition)
+      }
+    } else if (placement === 'top') {
+      horzOffset = horzOffset || 0
+      vertOffset = vertOffset || this.props.offset.default
+      position = {
+        left: referencePosition.left + (referencePosition.width / 2) + horzOffset,
+        top: referencePosition.top - vertOffset
+      }
+    } else if (placement === 'bottom') {
+      horzOffset = horzOffset || 0
+      vertOffset = vertOffset || this.props.offset.default
+      position = {
+        left: referencePosition.left + (referencePosition.width / 2) + horzOffset,
+        top: referencePosition.top + referencePosition.height + vertOffset
+      }
+    }
+
+    this.setState({
+      position
+    })
+    return position
+  },
+
+  /**
+   * Public interface: Opens the `Portal`
+   */
+  openPopout () {
+    this.calculatePosition()
+    return this.refs.portal.openPortal()
+  },
+
+  /**
+   * Public: Close the `Portal`
+   */
+  closePopout () {
+    return this.refs.portal.closePortal()
+  },
+
+  /**
+   * Return the `container` node
+   */
+  getContainer () {
+    return this.refs.container
+  },
+
+  onResize (e) {
+    this.calculatePosition()
+  },
+
+  render () {
+    // Extract Portal props
+    let {
+      closeOnEsc,
+      closeOnOutsideClick,
+      openByClickOn,
+      onOpen,
+      beforeClose,
+      onClose,
+      onUpdate,
+    } = this.props
+
+    let { placement } = this.props
+    let { position } = this.state
+
+    // Extract the reference element
+    // AKA child.first
+    let children = React.Children.toArray(this.props.children)
+    let reference = children[0]
+
+    let containerClassNames = classNames(
+      styles.container,
+      [`${styles['container--' + placement]}`]
+    )
+    let arrowClassNames = classNames(
+      styles.containerArrow,
+      [`${styles['containerArrow--' + placement]}`]
+    )
+
+    return (
+      <div>
+        <div ref='reference'>
+          { reference }
+        </div>
+        <Portal
+          ref='portal'
+          closeOnEsc={closeOnEsc}
+          closeOnOutsideClick={closeOnOutsideClick}
+          openByClickOn={openByClickOn}
+          onOpen={onOpen}
+          beforeClose={beforeClose}
+          onClose={onClose}
+          onUpdate={onUpdate}>
+          <div className={styles.positioner} style={position}>
+            <div className={arrowClassNames}/>
+            <div ref='container' className={containerClassNames}>
+              {children.slice(1)}
+            </div>
+          </div>
+        </Portal>
+      </div>
+    )
+  }
+})
+
+export default Popout

--- a/src/components/ui/popout/popout.mcss
+++ b/src/components/ui/popout/popout.mcss
@@ -1,0 +1,125 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value popovers: '../popovers.mcss';
+@value greyLight, white from styles;
+
+.positioner {
+  position: absolute;
+  height: 0;
+  width: 0;
+}
+
+.container {
+  composes: normal sans whiteBackground from styles;
+  composes: popover from popovers;
+  border-radius: 3px;
+  max-height: 40rem;
+  max-width: 100vh;
+  min-height: 14rem;
+  min-width: 14rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  position: absolute;
+}
+
+.container--left {
+  right: 0;
+  top: 0;
+}
+
+.container--right {
+  left: 0;
+  top: 0;
+}
+
+.container--top {
+  bottom: 0;
+  left: 0;
+  transform: translateX(-50%);
+}
+
+.container--bottom {
+  top: 0;
+  left: 0;
+  transform: translateX(-50%);
+}
+
+/**
+ * Arrow is separate to avoid overflow issues
+ */
+.containerArrow {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+}
+  .containerArrow:after,
+  .containerArrow:before {
+    border-color: transparent;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+  }
+
+.containerArrow--left {
+  left: -1px;
+  top: 1.2rem;
+}
+  .containerArrow--left:before {
+    border-left-color: greyLight;
+    border-width: 6px;
+    margin-top: -1px;
+  }
+  .containerArrow--left:after {
+    border-left-color: white;
+    border-width: 5px;
+  }
+
+.containerArrow--right {
+  top: 1.2rem;
+  margin-left: -9px;
+}
+  .containerArrow--right:before {
+    border-right-color: greyLight;
+    border-width: 6px;
+    margin-left: -2px;
+    margin-top: -1px;
+  }
+  .containerArrow--right:after {
+    border-right-color: white;
+    border-width: 5px;
+  }
+.containerArrow--top {
+  margin-top: -1px;
+  left: 50%;
+  top: 100%;
+}
+  .containerArrow--top:before {
+    border-top-color: greyLight;
+    border-width: 6px;
+    margin-left: -6px;
+  }
+  .containerArrow--top:after {
+    border-top-color: white;
+    border-width: 5px;
+    margin-left: -5px;
+  }
+.containerArrow--bottom {
+  bottom: 100%;
+  left: 50%;
+  top: 1px;
+}
+  .containerArrow--bottom:before {
+    border-bottom-color: greyLight;
+    border-width: 6px;
+    margin-left: -6px;
+  }
+  .containerArrow--bottom:after {
+    border-bottom-color: white;
+    border-width: 5px;
+    margin-left: -5px;
+  }


### PR DESCRIPTION
Poorly named branch, but this added a `<Popout/>` component. Works the same as the `<Popunder/>` for the most part: the first of `props.children` is considered the reference element that the "popout" is popping-out from, and the rest of the children are considered the content of the popout.

You can pass a `placement` prop of `top/right/bottom/left` that’ll determine the position of the `Popout`.

The component also takes all the the props that a [react-portal](https://github.com/tajo/react-portal) can handle.