### PR TITLE
Modal component

### DIFF
--- a/lib/components/ui/modal/index.js
+++ b/lib/components/ui/modal/index.js
@@ -1,6 +1,144 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = {};
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactPortal = require('react-portal');
+
+var _reactPortal2 = _interopRequireDefault(_reactPortal);
+
+var _modal = require('./modal.mcss');
+
+var _modal2 = _interopRequireDefault(_modal);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * A "modal" component.
+ *
+ * Exposes:
+ *
+ * @method openModal
+ * @method closeModal
+ * @method getContainer
+ */
+var Modal = _react2.default.createClass({
+  displayName: 'Modal',
+
+
+  propTypes: {
+    beforeClose: _react2.default.PropTypes.func,
+    children: _react2.default.PropTypes.node,
+    closeOnEsc: _react2.default.PropTypes.bool,
+    closeOnOutsideClick: _react2.default.PropTypes.bool,
+    openByClickOn: _react2.default.PropTypes.node,
+    onOpen: _react2.default.PropTypes.func,
+    onClose: _react2.default.PropTypes.func,
+    onUpdate: _react2.default.PropTypes.func
+  },
+
+  /**
+   * Public interface: Opens the `Portal`
+   */
+  openModal: function openModal() {
+    return this.refs.portal.openPortal();
+  },
+
+
+  /**
+   * Public: Close the `Portal`
+   */
+  closeModal: function closeModal() {
+    return this.refs.portal.closePortal();
+  },
+
+
+  /**
+   * Return the `container` node
+   */
+  getContainer: function getContainer() {
+    return this.refs.container;
+  },
+  onOpen: function onOpen(portalEl) {
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.left = "0";
+    document.body.style.right = "0";
+    if (this.props.onOpen) {
+      this.props.onOpen(portalEl);
+    }
+  },
+  onClose: function onClose(portalEl) {
+    document.body.style.overflow = "";
+    document.body.style.position = "";
+    document.body.style.left = "";
+    document.body.style.right = "";
+    if (this.props.onClose) {
+      this.props.onClose(portalEl);
+    }
+  },
+  onCloseClick: function onCloseClick(e) {
+    e.preventDefault();
+    this.closeModal();
+  },
+  onOverlayClick: function onOverlayClick(e) {
+    e.preventDefault();
+    this.closeModal();
+  },
+  render: function render() {
+    // Extract Portal props
+    var _props = this.props;
+    var closeOnEsc = _props.closeOnEsc;
+    var closeOnOutsideClick = _props.closeOnOutsideClick;
+    var openByClickOn = _props.openByClickOn;
+    var onOpen = _props.onOpen;
+    var beforeClose = _props.beforeClose;
+    var onClose = _props.onClose;
+    var onUpdate = _props.onUpdate;
+
+
+    return _react2.default.createElement(
+      _reactPortal2.default,
+      {
+        ref: 'portal',
+        closeOnEsc: closeOnEsc,
+        closeOnOutsideClick: closeOnOutsideClick,
+        openByClickOn: openByClickOn,
+        onOpen: this.onOpen,
+        beforeClose: beforeClose,
+        onClose: this.onClose,
+        onUpdate: onUpdate },
+      _react2.default.createElement(
+        'div',
+        { ref: 'container', className: _modal2.default.container },
+        _react2.default.createElement(
+          'button',
+          { className: _modal2.default.close, onClick: this.onCloseClick },
+          _react2.default.createElement(
+            'span',
+            { className: _modal2.default.closeText },
+            'Close'
+          ),
+          _react2.default.createElement(
+            'div',
+            { className: _modal2.default.closeX },
+            '×'
+          )
+        ),
+        _react2.default.createElement('button', { className: _modal2.default.overlay, onClick: this.onOverlayClick }),
+        _react2.default.createElement(
+          'div',
+          { className: _modal2.default.content },
+          this.props.children
+        )
+      )
+    );
+  }
+});
+
+exports.default = Modal;

--- a/lib/components/ui/modal/modal.mcss
+++ b/lib/components/ui/modal/modal.mcss
@@ -1,0 +1,53 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error from styles;
+
+.container {
+  bottom: 0;
+  left: 0;
+  overflow-scroll: touch;
+  overflow-y: scroll;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 3;
+}
+  .closeText {
+    display: none;
+  }
+  .closeX {
+    composes: fallback large primaryColor from styles;
+    cursor: pointer;
+    padding: 1rem;
+  }
+    .closeX:hover {
+      color: error;
+    }
+
+.overlay {
+  composes: lightBlendBackground from styles;
+  border: none;
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+.content > * {
+  position: relative;
+  z-index: 2;
+  max-width: 300px;
+  margin: 0 auto;
+}

--- a/lib/components/ui/theme/colours.mcss
+++ b/lib/components/ui/theme/colours.mcss
@@ -123,8 +123,16 @@ greys
 @value darkBlend: rgba(0,0,0,0.9);
 @value lightBlend: rgba(0,0,0,0.2);
 
+.darkBlendBackground {
+  background-color: darkBlend;
+}
+
 .darkBlendColor {
   color: darkBlend;
+}
+
+.lightBlendBackground {
+  background-color: lightBlend;
 }
 
 .lightBlendColor {

--- a/lib/components/ui/theme/typography.mcss
+++ b/lib/components/ui/theme/typography.mcss
@@ -6,6 +6,7 @@
 @value fontSans: 'Work Sans', 'Helvetica', sans-serif;
 @value fontfontSansBoldWeight: 700;
 @value fontMono: 'Inconsolata', monospace;
+@value fontFallback: 'Helvetica', sans-serif;
 
 .sans {
   font-family: fontSans;
@@ -22,6 +23,14 @@
 
 .mono {
   font-family: fontMono;
+}
+
+/**
+ * Monospace: Inconsolata
+ */
+
+.fallback {
+  font-family: fontFallback;
 }
 
 /* Line height */

--- a/src/components/ui/modal/index.js
+++ b/src/components/ui/modal/index.js
@@ -1,1 +1,115 @@
-export default {}
+import React from 'react'
+import Portal from 'react-portal'
+import styles from './modal.mcss'
+
+/**
+ * A "modal" component.
+ *
+ * Exposes:
+ *
+ * @method openModal
+ * @method closeModal
+ * @method getContainer
+ */
+const Modal = React.createClass({
+
+  propTypes: {
+    beforeClose: React.PropTypes.func,
+    children: React.PropTypes.node,
+    closeOnEsc: React.PropTypes.bool,
+    closeOnOutsideClick: React.PropTypes.bool,
+    openByClickOn: React.PropTypes.node,
+    onOpen: React.PropTypes.func,
+    onClose: React.PropTypes.func,
+    onUpdate: React.PropTypes.func
+  },
+
+  /**
+   * Public interface: Opens the `Portal`
+   */
+  openModal () {
+    return this.refs.portal.openPortal()
+  },
+
+  /**
+   * Public: Close the `Portal`
+   */
+  closeModal () {
+    return this.refs.portal.closePortal()
+  },
+
+  /**
+   * Return the `container` node
+   */
+  getContainer () {
+    return this.refs.container
+  },
+
+  onOpen (portalEl) {
+    document.body.style.overflow = "hidden"
+    document.body.style.position = "fixed"
+    document.body.style.left = "0"
+    document.body.style.right = "0"
+    if (this.props.onOpen) {
+      this.props.onOpen(portalEl)
+    }
+  },
+
+  onClose (portalEl) {
+    document.body.style.overflow = ""
+    document.body.style.position = ""
+    document.body.style.left = ""
+    document.body.style.right = ""
+    if (this.props.onClose) {
+      this.props.onClose(portalEl)
+    }
+  },
+
+  onCloseClick (e) {
+    e.preventDefault()
+    this.closeModal()
+  },
+
+  onOverlayClick (e) {
+    e.preventDefault()
+    this.closeModal()
+  },
+
+  render () {
+    // Extract Portal props
+    let {
+      closeOnEsc,
+      closeOnOutsideClick,
+      openByClickOn,
+      onOpen,
+      beforeClose,
+      onClose,
+      onUpdate,
+    } = this.props
+
+    return (
+      <Portal
+        ref='portal'
+        closeOnEsc={closeOnEsc}
+        closeOnOutsideClick={closeOnOutsideClick}
+        openByClickOn={openByClickOn}
+        onOpen={this.onOpen}
+        beforeClose={beforeClose}
+        onClose={this.onClose}
+        onUpdate={onUpdate}>
+        <div ref='container' className={styles.container}>
+          <button className={styles.close}  onClick={this.onCloseClick}>
+            <span className={styles.closeText}>Close</span>
+            <div className={styles.closeX}>&times;</div>
+          </button>
+          <button className={styles.overlay} onClick={this.onOverlayClick}/>
+          <div className={styles.content}>
+            {this.props.children}
+          </div>
+        </div>
+      </Portal>
+    )
+  }
+})
+
+export default Modal

--- a/src/components/ui/modal/modal.mcss
+++ b/src/components/ui/modal/modal.mcss
@@ -1,0 +1,53 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error from styles;
+
+.container {
+  bottom: 0;
+  left: 0;
+  overflow-scroll: touch;
+  overflow-y: scroll;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 3;
+}
+  .closeText {
+    display: none;
+  }
+  .closeX {
+    composes: fallback large primaryColor from styles;
+    cursor: pointer;
+    padding: 1rem;
+  }
+    .closeX:hover {
+      color: error;
+    }
+
+.overlay {
+  composes: lightBlendBackground from styles;
+  border: none;
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+.content > * {
+  position: relative;
+  z-index: 2;
+  max-width: 300px;
+  margin: 0 auto;
+}

--- a/src/components/ui/theme/colours.mcss
+++ b/src/components/ui/theme/colours.mcss
@@ -123,8 +123,16 @@ greys
 @value darkBlend: rgba(0,0,0,0.9);
 @value lightBlend: rgba(0,0,0,0.2);
 
+.darkBlendBackground {
+  background-color: darkBlend;
+}
+
 .darkBlendColor {
   color: darkBlend;
+}
+
+.lightBlendBackground {
+  background-color: lightBlend;
 }
 
 .lightBlendColor {

--- a/src/components/ui/theme/typography.mcss
+++ b/src/components/ui/theme/typography.mcss
@@ -6,6 +6,7 @@
 @value fontSans: 'Work Sans', 'Helvetica', sans-serif;
 @value fontfontSansBoldWeight: 700;
 @value fontMono: 'Inconsolata', monospace;
+@value fontFallback: 'Helvetica', sans-serif;
 
 .sans {
   font-family: fontSans;
@@ -22,6 +23,14 @@
 
 .mono {
   font-family: fontMono;
+}
+
+/**
+ * Monospace: Inconsolata
+ */
+
+.fallback {
+  font-family: fontFallback;
 }
 
 /* Line height */


### PR DESCRIPTION
Adds a `<Modal/>` component. Pretty similar to `<Popout/>` and `<Popunder/>` though it is more straightforward since it doesn’t need to do the dance of having a reference node for positioning.

`Modal` shells out straight to a `react-portal`. It doesn’t have much opinion about the styling of the contents of the modal, though it creates an overlay that will close the modal when clicked on. If the content of the modal fills the entire screen the overlay won’t be visible.