### PR TITLE
Sortable send click event on remove

### DIFF
--- a/lib/components/ui/sortable/index.js
+++ b/lib/components/ui/sortable/index.js
@@ -161,7 +161,7 @@ var Sortable = _react2.default.createClass({
 
     return _react2.default.createElement(
       'div',
-      { className: _sortable2.default.base },
+      { className: _sortable2.default.base, 'data-name': 'sortable-items' },
       items.map(function (item, index) {
         return _react2.default.createElement(
           _item2.default,

--- a/lib/components/ui/sortable/item.js
+++ b/lib/components/ui/sortable/item.js
@@ -162,7 +162,7 @@ var Item = _react2.default.createClass({
   },
 
   /**
-   * Send current `index` to the onRemove callback
+   * Send current `index` and click event to the onRemove callback
    * @param  {Event} e Click event
    */
   onRemoveClick: function onRemoveClick(e) {
@@ -172,8 +172,9 @@ var Item = _react2.default.createClass({
     var onRemove = _props.onRemove;
 
     if (canRemove && onRemove) {
-      onRemove(this.props.index);
+      onRemove(this.props.index, e);
     }
+    ree;
   },
 
 
@@ -203,7 +204,7 @@ var Item = _react2.default.createClass({
 
     return connectDropTarget(connectDragPreview(_react2.default.createElement(
       'div',
-      { className: _item2.default.base, style: inline },
+      { className: _item2.default.base, style: inline, 'data-name': 'sortable-item' },
       _react2.default.createElement(
         'div',
         { className: _item2.default.inner },

--- a/lib/components/ui/sortable/item.js
+++ b/lib/components/ui/sortable/item.js
@@ -174,7 +174,6 @@ var Item = _react2.default.createClass({
     if (canRemove && onRemove) {
       onRemove(this.props.index, e);
     }
-    ree;
   },
 
 

--- a/src/components/ui/radio-button/index.js
+++ b/src/components/ui/radio-button/index.js
@@ -57,7 +57,6 @@ const RadioButton = React.createClass({
     this.setState({focus: true})
   },
 
-
   render () {
     let { defaultChecked, label, name, onChange, value } = this.props
     let labelClassNames = classNames(

--- a/src/components/ui/sortable/index.js
+++ b/src/components/ui/sortable/index.js
@@ -126,7 +126,7 @@ const Sortable = React.createClass({
     const canSort = (items.length > 1)
 
     return (
-      <div className={styles.base}>
+      <div className={styles.base} data-name="sortable-items">
         {items.map((item, index) => (
           <Item
             key={`${instanceKey}_${item.originalIndex}`}

--- a/src/components/ui/sortable/index.js
+++ b/src/components/ui/sortable/index.js
@@ -126,7 +126,7 @@ const Sortable = React.createClass({
     const canSort = (items.length > 1)
 
     return (
-      <div className={styles.base} data-name="sortable-items">
+      <div className={styles.base} data-name='sortable-items'>
         {items.map((item, index) => (
           <Item
             key={`${instanceKey}_${item.originalIndex}`}

--- a/src/components/ui/sortable/item.js
+++ b/src/components/ui/sortable/item.js
@@ -142,15 +142,16 @@ const Item = React.createClass({
   },
 
   /**
-   * Send current `index` to the onRemove callback
+   * Send current `index` and click event to the onRemove callback
    * @param  {Event} e Click event
    */
   onRemoveClick (e) {
     e.preventDefault()
     const { canRemove, onRemove } = this.props
     if (canRemove && onRemove) {
-      onRemove(this.props.index)
+      onRemove(this.props.index, e)
     }
+    ree
   },
 
   /**
@@ -176,7 +177,7 @@ const Item = React.createClass({
 
     return connectDropTarget(
       connectDragPreview(
-        <div className={styles.base} style={inline}>
+        <div className={styles.base} style={inline}  data-name="sortable-item">
           <div className={styles.inner}>
             {children}
           </div>

--- a/src/components/ui/sortable/item.js
+++ b/src/components/ui/sortable/item.js
@@ -151,7 +151,6 @@ const Item = React.createClass({
     if (canRemove && onRemove) {
       onRemove(this.props.index, e)
     }
-    ree
   },
 
   /**
@@ -177,7 +176,7 @@ const Item = React.createClass({
 
     return connectDropTarget(
       connectDragPreview(
-        <div className={styles.base} style={inline}  data-name="sortable-item">
+        <div className={styles.base} style={inline} data-name='sortable-item'>
           <div className={styles.inner}>
             {children}
           </div>


### PR DESCRIPTION
This PR adds a `data-name="sortable-items` to the main wrapper of sortable items.
It also adds a `data-name="sortable-item` to each sortable item.

This makes it very easy to target items with JS instead of relying on class names generated by css modules. The reason why we need to be able to target sortable items is in case we want to do 'something else' when removing an item.

For instance, when creating sortable uploaded files - I need to ensure that the uploaded file that was removed, also has it's record removed from the state of the `multi-upload-field` component I'm building.

By returning the click event along with the index of the Sortable items `onRemove` function, we then have access to the element (well, the `x` button) . We can then (scoping to the `data-name` attributes above) search the sortable item for specific data-attributes/classes of it's contents and then do what we wish.



