### PR TITLE
Attache response

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -311,7 +311,6 @@ var MultiUploadField = _react2.default.createClass({
 
     var value = multiple ? uploadedFiles : uploadedFiles[0];
 
-    debugger;
     this.props.actions.edit(function (val) {
       return _immutable2.default.fromJS(value);
     });

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -268,25 +268,19 @@ var MultiUploadField = _react2.default.createClass({
    * Iterate previewFiles and return all files that are not `file`
    * Push `file` into uploadedFiles and save the state
    * @param {object} a file object
+   * @param {object} attache server response
    */
 
   updateUploadedFiles: function updateUploadedFiles(fileObject, response) {
-    var path = response.path;
-    var geometry = response.geometry;
-    var uploadURL = response.uploadURL;
-
-
     var previewFiles = this.state.previewFiles.filter(function (preview) {
       return preview.file_name !== fileObject.file_name;
     });
 
     var uploadedFiles = this.state.uploadedFiles ? this.state.uploadedFiles.slice(0) : [];
 
-    // apply additional properties to fileObject before saving to state
-    fileObject.path = path;
-    fileObject.geometry = geometry;
-    fileObject.uploadURL = uploadURL;
-    fileObject.original_url = this.buildPath(uploadURL, path);
+    // store the response from attache to the fileObject
+    // so we can export easily in onUpdate()
+    fileObject.attache_response = response;
     uploadedFiles.push(fileObject);
 
     this.setState({
@@ -309,28 +303,18 @@ var MultiUploadField = _react2.default.createClass({
   onUpdate: function onUpdate(uploadedFiles) {
     var multiple = this.props.multiple;
 
-    // delete `file` from each fileObject
+    // abstract attache_response from each uploaded file
 
-    uploadedFiles.map(this.normaliseFileExport);
+    uploadedFiles.map(function (fileObject) {
+      return fileObject.attache_response;
+    });
+
     var value = multiple ? uploadedFiles : uploadedFiles[0];
 
+    debugger;
     this.props.actions.edit(function (val) {
       return _immutable2.default.fromJS(value);
     });
-  },
-
-
-  /**
-   * normaliseFileExport
-   * Remove any values we don’t care about persisting, mostly the `file`
-   * attribute/object that we use for previewing
-   * @param {object} file object
-   */
-
-  normaliseFileExport: function normaliseFileExport(obj) {
-    var copy = Object.assign({}, obj);
-    delete copy.file;
-    return copy;
   },
 
 
@@ -855,11 +839,13 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   renderUploadedFileItem: function renderUploadedFileItem(fileObject, idx) {
-    var path = fileObject.path;
+    var attache_response = fileObject.attache_response;
     var file_name = fileObject.file_name;
-    var uploadURL = fileObject.uploadURL;
-    var original_url = fileObject.original_url;
     var thumbnail_url = fileObject.thumbnail_url;
+    var path = attache_response.path;
+    var uploadURL = attache_response.uploadURL;
+
+    var original_url = this.buildPath(uploadURL, path);
 
     var hasThumbnail = thumbnail_url != null || (0, _utils.filenameIsImage)(file_name);
     var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, file_name, uploadURL, path) : null;


### PR DESCRIPTION
This PR stores the complete response from the attache server to a property on the `fileObject` named `attache_response`.

On `onUpdate()` we iterate the `fileObject` and abstract this one property.

The values in `attache_response` are then directly referenced in `renderUploadedFileItem`