### PR TITLE
Export file-attributes when file has uploaded

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -195,7 +195,7 @@ var MultiUploadField = _react2.default.createClass({
 
       return {
         file: file,
-        file_name: name,
+        name: name,
         size: size,
         type: type,
         lastModifiedDate: lastModifiedDate.toString(),
@@ -251,7 +251,7 @@ var MultiUploadField = _react2.default.createClass({
     var previewFiles = this.state.previewFiles ? this.state.previewFiles.slice(0) : [];
 
     previewFiles.map(function (file) {
-      if (file.file_name === name) {
+      if (file.name === name) {
         file.progress = e.percent;
       }
     });
@@ -270,19 +270,15 @@ var MultiUploadField = _react2.default.createClass({
    * @param {object} a file object
    */
 
-  updateUploadedFiles: function updateUploadedFiles(fileObject, response) {
-    var path = response.path;
-    var uploadURL = response.uploadURL;
-
-
+  updateUploadedFiles: function updateUploadedFiles(fileObject, response, upload_url) {
     var previewFiles = this.state.previewFiles.filter(function (preview) {
-      return preview.file_name !== fileObject.file_name;
+      return preview.name !== fileObject.name;
     });
 
     var uploadedFiles = this.state.uploadedFiles ? this.state.uploadedFiles.slice(0) : [];
 
     fileObject.fileAttributes = response;
-    fileObject.original_url = this.buildPath(uploadURL, path);
+    fileObject.original_url = this.buildPath(upload_url, response.path);
     uploadedFiles.push(fileObject);
 
     this.setState({
@@ -323,6 +319,10 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   normaliseFileExport: function normaliseFileExport(obj) {
+    if (!obj.hasOwnProperty('fileAttributes')) {
+      return obj;
+    }
+
     var copy = Object.assign({}, obj);
     delete copy.fileAttributes.uploadURL;
     return copy.fileAttributes;
@@ -389,12 +389,18 @@ var MultiUploadField = _react2.default.createClass({
     var presign_url = this.props.attributes.presign_url;
     var csrfToken = this.context.globalConfig.csrfToken;
 
+    var upload_url = void 0;
 
     (0, _attacheUpload.presign)(presign_url, csrfToken).then(function (presignResponse) {
+
+      // assign the return 'url' to upload_url so
+      // we can create paths to the file
+      upload_url = presignResponse.url;
+
       return (0, _attacheUpload.upload)(presignResponse, fileObject, onProgress);
     }).then(function (uploadResponse) {
       if (!updateUploadedFilesStatus) return;
-      return _this.updateUploadedFiles(fileObject, uploadResponse);
+      return _this.updateUploadedFiles(fileObject, uploadResponse, upload_url);
     }).catch(function (err) {
       _this.removeFileFromPreviewFiles(fileObject);
       _this.storeXHRErrorMessage(err.message);
@@ -763,9 +769,9 @@ var MultiUploadField = _react2.default.createClass({
   renderPreviewItem: function renderPreviewItem(fileObject, i) {
     var progress = fileObject.progress;
     var file = fileObject.file;
+    var name = fileObject.name;
     var uid = fileObject.uid;
     var preview = file.preview;
-    var name = file.name;
 
     var hasThumbnail = (0, _utils.filenameIsImage)(name);
     var thumbnailImage = hasThumbnail ? this.renderThumbnail(preview, null, name) : null;
@@ -869,16 +875,12 @@ var MultiUploadField = _react2.default.createClass({
   renderUploadedFileItem: function renderUploadedFileItem(fileObject, idx) {
     var file = fileObject.file;
     var fileAttributes = fileObject.fileAttributes;
-    var thumbnail_url = fileAttributes.thumbnail_url;
-    var original_url = fileAttributes.original_url;
+    var name = fileObject.name;
+    var thumbnail_url = fileObject.thumbnail_url;
+    var original_url = fileObject.original_url;
 
-
-    var originalURL = fileObject.original_url || fileAttributes.original_url;
-
-    var file_name = fileAttributes.name != null ? fileAttributes.name : file.name;
-
-    var hasThumbnail = thumbnail_url != null || (0, _utils.filenameIsImage)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, originalURL, file_name) : null;
+    var hasThumbnail = thumbnail_url != null || (0, _utils.filenameIsImage)(name);
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, original_url, name) : null;
 
     var bodyClassNames = (0, _classnames2.default)(_index2.default.listItem__body, _index2.default.fade_in);
 
@@ -908,8 +910,8 @@ var MultiUploadField = _react2.default.createClass({
               { className: _index2.default.listItem__title },
               _react2.default.createElement(
                 'a',
-                { target: '_blank', href: originalURL },
-                file_name
+                { target: '_blank', href: original_url },
+                name
               )
             )
           )

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -131,14 +131,6 @@ var MultiUploadField = _react2.default.createClass({
     var uploadedFiles = [];
     var previewFiles = [];
 
-    value = [{
-      fileAttributes: {
-        "original_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/original/mullet.png",
-        "thumbnail_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/50x/mullet.png",
-        "name": "foo"
-      }
-    }];
-
     // is not null/array but is an object
     // or is a List with a size greater than 0
     if (value != null && !Array.isArray(value) && (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object') {
@@ -316,8 +308,6 @@ var MultiUploadField = _react2.default.createClass({
     var uploadedFiles = fileObjects.map(this.normaliseFileExport);
     var value = multiple ? uploadedFiles : uploadedFiles[0];
 
-    console.log(value);
-
     this.props.actions.edit(function (val) {
       return _immutable2.default.fromJS(value);
     });
@@ -339,11 +329,12 @@ var MultiUploadField = _react2.default.createClass({
 
 
   /**
-   * [applyAttribute description]
-   * @param  {[type]} obj   [description]
-   * @param  {[type]} name  [description]
-   * @param  {[type]} value [description]
-   * @return {[type]}       [description]
+   * applyAttribute
+   * Copy an object and apply a property and value to it.
+   * @param  {object} obj
+   * @param  {string} name
+   * @param  value
+   * @return {object}
    */
 
   applyAttribute: function applyAttribute(obj, name, value) {
@@ -869,9 +860,10 @@ var MultiUploadField = _react2.default.createClass({
 
   /**
    * buildThumbnailPath
-   * @param  {[type]} original_url [description]
-   * @param  {[type]} dimension    =             '50x' [description]
-   * @return {[type]}              [description]
+   * Replace 'original' with a specific dimension. Defaults to `50x`
+   * @param  {string} original_url
+   * @param  {string} dimension
+   * @return {string}
    */
 
   buildThumbnailPath: function buildThumbnailPath(original_url) {

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -323,8 +323,8 @@ var MultiUploadField = _react2.default.createClass({
 
   normaliseFileExport: function normaliseFileExport(obj) {
     var copy = Object.assign({}, obj);
-    delete obj.fileAttributes.uploadURL;
-    return obj.fileAttributes;
+    delete copy.fileAttributes.uploadURL;
+    return copy.fileAttributes;
   },
 
 

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -131,6 +131,14 @@ var MultiUploadField = _react2.default.createClass({
     var uploadedFiles = [];
     var previewFiles = [];
 
+    value = [{
+      fileAttributes: {
+        "original_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/original/mullet.png",
+        "thumbnail_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/50x/mullet.png",
+        "name": "foo"
+      }
+    }];
+
     // is not null/array but is an object
     // or is a List with a size greater than 0
     if (value != null && !Array.isArray(value) && (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object') {
@@ -272,7 +280,6 @@ var MultiUploadField = _react2.default.createClass({
 
   updateUploadedFiles: function updateUploadedFiles(fileObject, response) {
     var path = response.path;
-    var geometry = response.geometry;
     var uploadURL = response.uploadURL;
 
 
@@ -282,11 +289,7 @@ var MultiUploadField = _react2.default.createClass({
 
     var uploadedFiles = this.state.uploadedFiles ? this.state.uploadedFiles.slice(0) : [];
 
-    // apply additional properties to fileObject before saving to state
-    fileObject.path = path;
-    fileObject.geometry = geometry;
-    fileObject.uploadURL = uploadURL;
-    fileObject.original_url = this.buildPath(uploadURL, path);
+    fileObject.fileAttributes = this.applyAttribute(response, 'original_url', this.buildPath(uploadURL, path));
     uploadedFiles.push(fileObject);
 
     this.setState({
@@ -306,13 +309,14 @@ var MultiUploadField = _react2.default.createClass({
    * @return {array/object}
    */
 
-  onUpdate: function onUpdate(uploadedFiles) {
+  onUpdate: function onUpdate(fileObjects) {
     var multiple = this.props.multiple;
 
-    // delete `file` from each fileObject
 
-    uploadedFiles.map(this.normaliseFileExport);
+    var uploadedFiles = fileObjects.map(this.normaliseFileExport);
     var value = multiple ? uploadedFiles : uploadedFiles[0];
+
+    console.log(value);
 
     this.props.actions.edit(function (val) {
       return _immutable2.default.fromJS(value);
@@ -329,7 +333,22 @@ var MultiUploadField = _react2.default.createClass({
 
   normaliseFileExport: function normaliseFileExport(obj) {
     var copy = Object.assign({}, obj);
-    delete copy.file;
+    delete obj.fileAttributes.uploadURL;
+    return obj.fileAttributes;
+  },
+
+
+  /**
+   * [applyAttribute description]
+   * @param  {[type]} obj   [description]
+   * @param  {[type]} name  [description]
+   * @param  {[type]} value [description]
+   * @return {[type]}       [description]
+   */
+
+  applyAttribute: function applyAttribute(obj, name, value) {
+    var copy = Object.assign({}, obj);
+    copy[name] = value;
     return copy;
   },
 
@@ -710,16 +729,18 @@ var MultiUploadField = _react2.default.createClass({
 
 
   /**
-   * [renderThumbnail description]
-   * @param  {[type]} thumbnail_url [description]
-   * @param  {[type]} name          [description]
-   * @param  {[type]} uploadURL     [description]
-   * @param  {[type]} path          [description]
-   * @return {[type]}               [description]
+   * renderThumbnail
+   * Return a thumbnail image based on `thumbnail_url` or building one from 'original_url'
+   * @param  {string} thumbnail_url
+   * @param  {string} original_url
+   * @param  {string} name
+   * @return {vnode}
    */
 
-  renderThumbnail: function renderThumbnail(url, name, uploadURL, path) {
-    return _react2.default.createElement('img', { src: url || this.buildPath(uploadURL, path, '50x'), alt: name });
+  renderThumbnail: function renderThumbnail(thumbnail_url, original_url, name) {
+    if (!thumbnail_url && !original_url) return;
+
+    return _react2.default.createElement('img', { src: thumbnail_url || this.buildThumbnailPath(original_url, '50x'), alt: name });
   },
 
 
@@ -767,11 +788,11 @@ var MultiUploadField = _react2.default.createClass({
     var progress = fileObject.progress;
     var file = fileObject.file;
     var uid = fileObject.uid;
-    var file_name = fileObject.file_name;
     var preview = file.preview;
+    var name = file.name;
 
-    var hasThumbnail = (0, _utils.filenameIsImage)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(preview, file_name) : null;
+    var hasThumbnail = (0, _utils.filenameIsImage)(name);
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(preview, null, name) : null;
 
     var currentProgress = {
       width: progress > 0 ? progress + '%' : '0%'
@@ -803,9 +824,9 @@ var MultiUploadField = _react2.default.createClass({
         {
           className: _index2.default.progress_bar,
           style: currentProgress },
-        this.renderPreviewDetails(file_name, thumbnailImage, true)
+        this.renderPreviewDetails(name, thumbnailImage, true)
       ),
-      this.renderPreviewDetails(file_name, thumbnailImage)
+      this.renderPreviewDetails(name, thumbnailImage)
     );
   },
 
@@ -847,6 +868,20 @@ var MultiUploadField = _react2.default.createClass({
 
 
   /**
+   * buildThumbnailPath
+   * @param  {[type]} original_url [description]
+   * @param  {[type]} dimension    =             '50x' [description]
+   * @return {[type]}              [description]
+   */
+
+  buildThumbnailPath: function buildThumbnailPath(original_url) {
+    var dimension = arguments.length <= 1 || arguments[1] === undefined ? '50x' : arguments[1];
+
+    return original_url.replace('original', dimension);
+  },
+
+
+  /**
    * renderUploadedFileItem
    * Render an node represeting an uploaded file
    * @param {object} fileObject
@@ -855,14 +890,16 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   renderUploadedFileItem: function renderUploadedFileItem(fileObject, idx) {
-    var path = fileObject.path;
-    var file_name = fileObject.file_name;
-    var uploadURL = fileObject.uploadURL;
-    var original_url = fileObject.original_url;
-    var thumbnail_url = fileObject.thumbnail_url;
+    var file = fileObject.file;
+    var fileAttributes = fileObject.fileAttributes;
+    var thumbnail_url = fileAttributes.thumbnail_url;
+    var original_url = fileAttributes.original_url;
+
+
+    var file_name = fileAttributes.name != null ? fileAttributes.name : file.name;
 
     var hasThumbnail = thumbnail_url != null || (0, _utils.filenameIsImage)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, file_name, uploadURL, path) : null;
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, original_url, file_name) : null;
 
     var bodyClassNames = (0, _classnames2.default)(_index2.default.listItem__body, _index2.default.fade_in);
 

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -281,7 +281,8 @@ var MultiUploadField = _react2.default.createClass({
 
     var uploadedFiles = this.state.uploadedFiles ? this.state.uploadedFiles.slice(0) : [];
 
-    fileObject.fileAttributes = this.applyAttribute(response, 'original_url', this.buildPath(uploadURL, path));
+    fileObject.fileAttributes = response;
+    fileObject.original_url = this.buildPath(uploadURL, path);
     uploadedFiles.push(fileObject);
 
     this.setState({
@@ -325,22 +326,6 @@ var MultiUploadField = _react2.default.createClass({
     var copy = Object.assign({}, obj);
     delete copy.fileAttributes.uploadURL;
     return copy.fileAttributes;
-  },
-
-
-  /**
-   * applyAttribute
-   * Copy an object and apply a property and value to it.
-   * @param  {object} obj
-   * @param  {string} name
-   * @param  value
-   * @return {object}
-   */
-
-  applyAttribute: function applyAttribute(obj, name, value) {
-    var copy = Object.assign({}, obj);
-    copy[name] = value;
-    return copy;
   },
 
 
@@ -888,10 +873,12 @@ var MultiUploadField = _react2.default.createClass({
     var original_url = fileAttributes.original_url;
 
 
+    var originalURL = fileObject.original_url || fileAttributes.original_url;
+
     var file_name = fileAttributes.name != null ? fileAttributes.name : file.name;
 
     var hasThumbnail = thumbnail_url != null || (0, _utils.filenameIsImage)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, original_url, file_name) : null;
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, originalURL, file_name) : null;
 
     var bodyClassNames = (0, _classnames2.default)(_index2.default.listItem__body, _index2.default.fade_in);
 
@@ -921,7 +908,7 @@ var MultiUploadField = _react2.default.createClass({
               { className: _index2.default.listItem__title },
               _react2.default.createElement(
                 'a',
-                { target: '_blank', href: original_url },
+                { target: '_blank', href: originalURL },
                 file_name
               )
             )

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "wr": "^1.3.1"
   },
   "dependencies": {
-    "attache-upload": "icelab/attache-upload.js",
+    "attache-upload": "2.1.0",
     "bus": "component/bus",
     "classnames": "^2.2.3",
     "es6-promise": "^3.1.2",

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -227,7 +227,8 @@ const MultiUploadField = React.createClass({
       ? this.state.uploadedFiles.slice(0)
       : []
 
-    fileObject.fileAttributes = this.applyAttribute(response, 'original_url', this.buildPath(uploadURL, path))
+    fileObject.fileAttributes = response
+    fileObject.original_url = this.buildPath(uploadURL, path)
     uploadedFiles.push(fileObject)
 
     this.setState({
@@ -268,21 +269,6 @@ const MultiUploadField = React.createClass({
     let copy = Object.assign({}, obj)
     delete copy.fileAttributes.uploadURL
     return copy.fileAttributes
-  },
-
-  /**
-   * applyAttribute
-   * Copy an object and apply a property and value to it.
-   * @param  {object} obj
-   * @param  {string} name
-   * @param  value
-   * @return {object}
-   */
-
-  applyAttribute (obj, name, value) {
-    let copy = Object.assign({}, obj)
-    copy[name] = value
-    return copy
   },
 
   /**
@@ -759,13 +745,15 @@ const MultiUploadField = React.createClass({
     const {file, fileAttributes} = fileObject
     const {thumbnail_url, original_url} = fileAttributes
 
+    const originalURL = fileObject.original_url || fileAttributes.original_url
+
     const file_name = fileAttributes.name != null
       ? fileAttributes.name
       : file.name
 
     const hasThumbnail = (thumbnail_url != null) || filenameIsImage(file_name)
     const thumbnailImage = hasThumbnail
-      ? this.renderThumbnail(thumbnail_url, original_url, file_name)
+      ? this.renderThumbnail(thumbnail_url, originalURL, file_name)
       : null
 
     const bodyClassNames = classNames(
@@ -784,7 +772,7 @@ const MultiUploadField = React.createClass({
             </div>
             <div className={styles.align_middle__content}>
               <div className={styles.listItem__title}>
-                <a target='_blank' href={original_url}>{file_name}</a>
+                <a target='_blank' href={originalURL}>{file_name}</a>
               </div>
             </div>
           </div>

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -85,16 +85,6 @@ const MultiUploadField = React.createClass({
     let uploadedFiles = []
     let previewFiles = []
 
-    value = [
-      {
-        fileAttributes: {
-          "original_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/original/mullet.png",
-          "thumbnail_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/50x/mullet.png",
-          "name": "foo"
-        }
-      }
-    ]
-
     // is not null/array but is an object
     // or is a List with a size greater than 0
     if (value != null && !Array.isArray(value) && (typeof (value) === 'object')) {
@@ -262,8 +252,6 @@ const MultiUploadField = React.createClass({
     const uploadedFiles = fileObjects.map(this.normaliseFileExport)
     const value = multiple ? uploadedFiles : uploadedFiles[0]
 
-    console.log(value)
-
     this.props.actions.edit(
       (val) => Immutable.fromJS(value)
     )
@@ -283,11 +271,12 @@ const MultiUploadField = React.createClass({
   },
 
   /**
-   * [applyAttribute description]
-   * @param  {[type]} obj   [description]
-   * @param  {[type]} name  [description]
-   * @param  {[type]} value [description]
-   * @return {[type]}       [description]
+   * applyAttribute
+   * Copy an object and apply a property and value to it.
+   * @param  {object} obj
+   * @param  {string} name
+   * @param  value
+   * @return {object}
    */
 
   applyAttribute (obj, name, value) {
@@ -747,9 +736,10 @@ const MultiUploadField = React.createClass({
 
   /**
    * buildThumbnailPath
-   * @param  {[type]} original_url [description]
-   * @param  {[type]} dimension    =             '50x' [description]
-   * @return {[type]}              [description]
+   * Replace 'original' with a specific dimension. Defaults to `50x`
+   * @param  {string} original_url
+   * @param  {string} dimension
+   * @return {string}
    */
 
   buildThumbnailPath (original_url, dimension = '50x') {

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -266,8 +266,8 @@ const MultiUploadField = React.createClass({
 
   normaliseFileExport (obj) {
     let copy = Object.assign({}, obj)
-    delete obj.fileAttributes.uploadURL
-    return obj.fileAttributes
+    delete copy.fileAttributes.uploadURL
+    return copy.fileAttributes
   },
 
   /**


### PR DESCRIPTION
This PR exports the attache server response on upload.

![fileattributes](https://cloud.githubusercontent.com/assets/121675/15694932/94093b1e-27e5-11e6-9fec-beb9987eb445.gif)

In this example, the existing file is loaded using the following data structure.

```
value = [
  {
    fileAttributes: {
      "original_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/original/mullet.png",
      "thumbnail_url": "http://icelab.attache.me/view/1a/84/db/cb/41/fc/37/f1/fe/da/79/ab/5a/cb/75/c2/50x/mullet.png",
      "name": "foo"
    }
  }
]
```

During the upload process the attache server's response is saved to the UI's `fileObject` like so:

```
{
  file: [ File ],
  fileAttributes: {
    // attache response
  },
  progress: 100 // used for rendering the upload progress
}
```

Once completed, we export just the `fileAttributes` of this object - as you'll see in the console of the example.

