### PR TITLE
Fix popups (again)

### DIFF
--- a/lib/components/fields/multi-selection-field/index.js
+++ b/lib/components/fields/multi-selection-field/index.js
@@ -127,7 +127,8 @@ var SelectionField = _react2.default.createClass({
    */
   getInitialState: function getInitialState() {
     return {
-      search: null
+      search: null,
+      searchFocus: false
     };
   },
 
@@ -252,6 +253,30 @@ var SelectionField = _react2.default.createClass({
       search: search
     });
   },
+
+
+  /**
+   * On search input focus
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchFocus: function onSearchFocus(e) {
+    this.setState({
+      searchFocus: true
+    });
+  },
+
+
+  /**
+   * On search input blur
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchBlur: function onSearchBlur(e) {
+    this.setState({
+      searchFocus: false
+    });
+  },
   render: function render() {
     var _this = this;
 
@@ -266,6 +291,7 @@ var SelectionField = _react2.default.createClass({
     var _state = this.state;
     var instanceKey = _state.instanceKey;
     var search = _state.search;
+    var searchFocus = _state.searchFocus;
     var options = attributes.options;
     var placeholder = attributes.placeholder;
     var selector_label = attributes.selector_label;
@@ -370,7 +396,7 @@ var SelectionField = _react2.default.createClass({
               _popout2.default,
               { ref: function ref(c) {
                   return _this._selector = c;
-                }, placement: 'left', onClose: this.onPopoutClose, onOpen: this.onPopoutOpen, closeOnOutsideClick: true },
+                }, placement: 'left', onClose: this.onPopoutClose, onOpen: this.onPopoutOpen, closeOnEsc: !searchFocus && !search, closeOnOutsideClick: true },
               _react2.default.createElement(
                 'div',
                 { className: _multiSelectionField2.default.openSelectorButton },
@@ -384,6 +410,8 @@ var SelectionField = _react2.default.createClass({
                   type: 'search',
                   className: _multiSelectionField2.default.search,
                   placeholder: 'Type to filter',
+                  onBlur: this.onSearchBlur,
+                  onFocus: this.onSearchFocus,
                   onChange: this.onSearchChange }),
                 _react2.default.createElement(
                   'div',

--- a/lib/components/fields/selection-field/index.js
+++ b/lib/components/fields/selection-field/index.js
@@ -86,7 +86,6 @@ SelectDefault.propTypes = {
 var SelectionField = _react2.default.createClass({
   displayName: 'SelectionField',
 
-
   propTypes: {
     actions: _react2.default.PropTypes.object,
     name: _react2.default.PropTypes.string,
@@ -121,7 +120,8 @@ var SelectionField = _react2.default.createClass({
    */
   getInitialState: function getInitialState() {
     return {
-      search: null
+      search: null,
+      searchFocus: false
     };
   },
 
@@ -227,8 +227,33 @@ var SelectionField = _react2.default.createClass({
       search: search
     });
   },
+
+
+  /**
+   * On search input focus
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchFocus: function onSearchFocus(e) {
+    this.setState({
+      searchFocus: true
+    });
+  },
+
+
+  /**
+   * On search input blur
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchBlur: function onSearchBlur(e) {
+    this.setState({
+      searchFocus: false
+    });
+  },
   render: function render() {
-    var _this = this;
+    var _this = this,
+        _React$createElement;
 
     var _props = this.props;
     var attributes = _props.attributes;
@@ -238,7 +263,9 @@ var SelectionField = _react2.default.createClass({
     var label = _props.label;
     var name = _props.name;
     var value = _props.value;
-    var search = this.state.search;
+    var _state = this.state;
+    var search = _state.search;
+    var searchFocus = _state.searchFocus;
     var options = attributes.options;
     var placeholder = attributes.placeholder;
     var selector_label = attributes.selector_label;
@@ -340,9 +367,9 @@ var SelectionField = _react2.default.createClass({
           ),
           _react2.default.createElement(
             _popout2.default,
-            { ref: function ref(c) {
+            (_React$createElement = { ref: function ref(c) {
                 return _this._selector = c;
-              }, placement: 'left', closeOnEsc: true, onClose: this.onPopoutClose, onOpen: this.onPopoutOpen, closeOnOutsideClick: true },
+              }, placement: 'left', closeOnEsc: true, onClose: this.onPopoutClose, onOpen: this.onPopoutOpen }, _defineProperty(_React$createElement, 'closeOnEsc', !searchFocus || !search), _defineProperty(_React$createElement, 'closeOnOutsideClick', true), _React$createElement),
             _react2.default.createElement(
               'div',
               { className: _selectionField2.default.openSelectorButton },
@@ -356,6 +383,8 @@ var SelectionField = _react2.default.createClass({
                 type: 'search',
                 className: _selectionField2.default.search,
                 placeholder: 'Type to filter',
+                onBlur: this.onSearchBlur,
+                onFocus: this.onSearchFocus,
                 onChange: this.onSearchChange }),
               _react2.default.createElement(
                 'div',

--- a/lib/components/ui/modal/index.js
+++ b/lib/components/ui/modal/index.js
@@ -32,22 +32,25 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Modal = _react2.default.createClass({
   displayName: 'Modal',
 
-  isOpened: false,
-
   propTypes: {
     beforeClose: _react2.default.PropTypes.func,
     children: _react2.default.PropTypes.node,
     closeOnEsc: _react2.default.PropTypes.bool,
     closeOnOutsideClick: _react2.default.PropTypes.bool,
-    openByClickOn: _react2.default.PropTypes.node,
     onOpen: _react2.default.PropTypes.func,
     onClose: _react2.default.PropTypes.func,
     onUpdate: _react2.default.PropTypes.func
   },
 
+  getInitialState: function getInitialState() {
+    return {
+      isOpened: false
+    };
+  },
   componentWillMount: function componentWillMount() {
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
+    document.addEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.addEventListener('mouseup', this.handleOutsideMouseClick);
       document.addEventListener('touchstart', this.handleOutsideMouseClick);
@@ -56,6 +59,7 @@ var Modal = _react2.default.createClass({
   componentWillUnmount: function componentWillUnmount() {
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
+    document.removeEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.removeEventListener('mouseup', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
@@ -67,7 +71,9 @@ var Modal = _react2.default.createClass({
    * Public interface: Opens the `Portal`
    */
   openModal: function openModal() {
-    this._portal.openPortal();
+    this.setState({
+      isOpened: true
+    });
   },
 
 
@@ -75,7 +81,9 @@ var Modal = _react2.default.createClass({
    * Public: Close the `Portal`
    */
   closeModal: function closeModal() {
-    this._portal.closePortal();
+    this.setState({
+      isOpened: false
+    });
   },
 
 
@@ -101,7 +109,7 @@ var Modal = _react2.default.createClass({
    * @return {Null}
    */
   handleOutsideMouseClick: function handleOutsideMouseClick(e) {
-    if (!this.isOpened) {
+    if (!this.state.isOpened) {
       return;
     }
 
@@ -116,10 +124,23 @@ var Modal = _react2.default.createClass({
     }
 
     e.stopPropagation();
-    this._portal.closePortal();
+    this.closeModal();
+  },
+
+
+  /**
+   * Close portal if escape is pressed
+   * @param  {KeyboardEvent} e
+   */
+  handleKeydown: function handleKeydown(e) {
+    var closeOnEsc = this.props.closeOnEsc;
+    // ESCAPE = 27
+
+    if (closeOnEsc && e.keyCode === 27 && this.state.isOpened) {
+      this.closePopunder();
+    }
   },
   onOpen: function onOpen(portalEl) {
-    this.isOpened = true;
     document.body.style.overflow = 'hidden';
     document.body.style.position = 'fixed';
     document.body.style.left = '0';
@@ -151,11 +172,9 @@ var Modal = _react2.default.createClass({
 
     // Extract Portal props
     var _props = this.props;
-    var closeOnEsc = _props.closeOnEsc;
-    var openByClickOn = _props.openByClickOn;
     var beforeClose = _props.beforeClose;
     var onUpdate = _props.onUpdate;
-
+    var isOpened = this.state.isOpened;
 
     return _react2.default.createElement(
       _reactPortal2.default,
@@ -163,10 +182,9 @@ var Modal = _react2.default.createClass({
         ref: function ref(c) {
           return _this._portal = c;
         },
-        closeOnEsc: closeOnEsc,
-        openByClickOn: openByClickOn,
-        onOpen: this.onOpen,
         beforeClose: beforeClose,
+        isOpened: isOpened,
+        onOpen: this.onOpen,
         onClose: this.onClose,
         onUpdate: onUpdate },
       _react2.default.createElement(

--- a/lib/components/ui/popout/index.js
+++ b/lib/components/ui/popout/index.js
@@ -50,8 +50,6 @@ var arrowVertPosition = 16;
 var Popout = _react2.default.createClass({
   displayName: 'Popout',
 
-  isOpened: false,
-
   propTypes: {
     beforeClose: _react2.default.PropTypes.func,
     children: _react2.default.PropTypes.node,
@@ -62,7 +60,6 @@ var Popout = _react2.default.createClass({
       vert: _react2.default.PropTypes.number,
       horz: _react2.default.PropTypes.number
     }),
-    openByClickOn: _react2.default.PropTypes.node,
     onOpen: _react2.default.PropTypes.func,
     onClose: _react2.default.PropTypes.func,
     onUpdate: _react2.default.PropTypes.func,
@@ -79,6 +76,7 @@ var Popout = _react2.default.createClass({
   },
   getInitialState: function getInitialState() {
     return {
+      isOpened: false,
       position: {
         left: 0,
         top: 0
@@ -92,6 +90,7 @@ var Popout = _react2.default.createClass({
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
     document.addEventListener('resize', this.onResize);
+    document.addEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.addEventListener('mouseup', this.handleOutsideMouseClick);
       document.addEventListener('touchstart', this.handleOutsideMouseClick);
@@ -101,6 +100,7 @@ var Popout = _react2.default.createClass({
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
     document.removeEventListener('resize', this.onResize);
+    document.removeEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.removeEventListener('mouseup', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
@@ -164,7 +164,9 @@ var Popout = _react2.default.createClass({
    */
   openPopout: function openPopout() {
     this.calculatePosition();
-    this._portal.openPortal();
+    this.setState({
+      isOpened: true
+    });
   },
 
 
@@ -172,7 +174,9 @@ var Popout = _react2.default.createClass({
    * Public: Close the `Portal`
    */
   closePopout: function closePopout() {
-    this._portal.closePortal();
+    this.setState({
+      isOpened: false
+    });
   },
 
 
@@ -198,7 +202,7 @@ var Popout = _react2.default.createClass({
    * @return {Null}
    */
   handleOutsideMouseClick: function handleOutsideMouseClick(e) {
-    if (!this.isOpened) {
+    if (!this.state.isOpened) {
       return;
     }
 
@@ -213,7 +217,21 @@ var Popout = _react2.default.createClass({
     }
 
     e.stopPropagation();
-    this._portal.closePortal();
+    this.closePopout();
+  },
+
+
+  /**
+   * Close portal if escape is pressed
+   * @param  {KeyboardEvent} e
+   */
+  handleKeydown: function handleKeydown(e) {
+    var closeOnEsc = this.props.closeOnEsc;
+    // ESCAPE = 27
+
+    if (closeOnEsc && e.keyCode === 27 && this.state.isOpened) {
+      this.closePopout();
+    }
   },
 
 
@@ -230,7 +248,6 @@ var Popout = _react2.default.createClass({
    * Keep track of open/close state
    */
   onOpen: function onOpen() {
-    this.isOpened = true;
     var onOpen = this.props.onOpen;
 
     if (onOpen) {
@@ -243,7 +260,6 @@ var Popout = _react2.default.createClass({
    * Keep track of open/close state
    */
   onClose: function onClose() {
-    this.isOpened = false;
     var onClose = this.props.onClose;
 
     if (onClose) {
@@ -255,12 +271,12 @@ var Popout = _react2.default.createClass({
 
     // Extract Portal props
     var _props = this.props;
-    var closeOnEsc = _props.closeOnEsc;
-    var openByClickOn = _props.openByClickOn;
     var beforeClose = _props.beforeClose;
     var onUpdate = _props.onUpdate;
     var placement = this.props.placement;
-    var position = this.state.position;
+    var _state = this.state;
+    var isOpened = _state.isOpened;
+    var position = _state.position;
 
     // Extract the reference element
     // AKA child.first
@@ -287,10 +303,9 @@ var Popout = _react2.default.createClass({
           ref: function ref(c) {
             return _this._portal = c;
           },
-          closeOnEsc: closeOnEsc,
-          openByClickOn: openByClickOn,
-          onOpen: this.onOpen,
           beforeClose: beforeClose,
+          isOpened: isOpened,
+          onOpen: this.onOpen,
           onClose: this.onClose,
           onUpdate: onUpdate },
         _react2.default.createElement(

--- a/lib/components/ui/popunder/index.js
+++ b/lib/components/ui/popunder/index.js
@@ -44,8 +44,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Popunder = _react2.default.createClass({
   displayName: 'Popunder',
 
-  isOpened: false,
-
   propTypes: {
     beforeClose: _react2.default.PropTypes.func,
     children: _react2.default.PropTypes.node,
@@ -55,7 +53,6 @@ var Popunder = _react2.default.createClass({
       left: _react2.default.PropTypes.number,
       top: _react2.default.PropTypes.number
     }),
-    openByClickOn: _react2.default.PropTypes.node,
     onOpen: _react2.default.PropTypes.func,
     onClose: _react2.default.PropTypes.func,
     onUpdate: _react2.default.PropTypes.func
@@ -71,6 +68,7 @@ var Popunder = _react2.default.createClass({
   },
   getInitialState: function getInitialState() {
     return {
+      isOpened: false,
       position: {
         left: 0,
         top: 0
@@ -84,6 +82,7 @@ var Popunder = _react2.default.createClass({
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
     document.addEventListener('resize', this.onResize);
+    document.addEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.addEventListener('mouseup', this.handleOutsideMouseClick);
       document.addEventListener('touchstart', this.handleOutsideMouseClick);
@@ -93,6 +92,7 @@ var Popunder = _react2.default.createClass({
     var closeOnOutsideClick = this.props.closeOnOutsideClick;
 
     document.removeEventListener('resize', this.onResize);
+    document.removeEventListener('keydown', this.handleKeydown);
     if (closeOnOutsideClick) {
       document.removeEventListener('mouseup', this.handleOutsideMouseClick);
       document.removeEventListener('touchstart', this.handleOutsideMouseClick);
@@ -125,7 +125,9 @@ var Popunder = _react2.default.createClass({
    */
   openPopunder: function openPopunder() {
     this.calculatePosition();
-    this._portal.openPortal();
+    this.setState({
+      isOpened: true
+    });
   },
 
 
@@ -133,7 +135,9 @@ var Popunder = _react2.default.createClass({
    * Public: Close the `Portal`
    */
   closePopunder: function closePopunder() {
-    this._portal.openPortal();
+    this.setState({
+      isOpened: false
+    });
   },
 
 
@@ -159,7 +163,7 @@ var Popunder = _react2.default.createClass({
    * @return {Null}
    */
   handleOutsideMouseClick: function handleOutsideMouseClick(e) {
-    if (!this.isOpened) {
+    if (!this.state.isOpened) {
       return;
     }
 
@@ -174,7 +178,21 @@ var Popunder = _react2.default.createClass({
     }
 
     e.stopPropagation();
-    this._portal.closePortal();
+    this.closePopunder();
+  },
+
+
+  /**
+   * Close portal if escape is pressed
+   * @param  {KeyboardEvent} e
+   */
+  handleKeydown: function handleKeydown(e) {
+    var closeOnEsc = this.props.closeOnEsc;
+    // ESCAPE = 27
+
+    if (closeOnEsc && e.keyCode === 27 && this.state.isOpened) {
+      this.closePopunder();
+    }
   },
 
 
@@ -191,7 +209,6 @@ var Popunder = _react2.default.createClass({
    * Keep track of open/close state
    */
   onOpen: function onOpen() {
-    this.isOpened = true;
     var onOpen = this.props.onOpen;
 
     if (onOpen) {
@@ -204,7 +221,6 @@ var Popunder = _react2.default.createClass({
    * Keep track of open/close state
    */
   onClose: function onClose() {
-    this.isOpened = false;
     var onClose = this.props.onClose;
 
     if (onClose) {
@@ -217,10 +233,11 @@ var Popunder = _react2.default.createClass({
     // Extract Portal props
     var _props = this.props;
     var closeOnEsc = _props.closeOnEsc;
-    var openByClickOn = _props.openByClickOn;
     var beforeClose = _props.beforeClose;
     var onUpdate = _props.onUpdate;
-    var position = this.state.position;
+    var _state = this.state;
+    var isOpened = _state.isOpened;
+    var position = _state.position;
 
     // Extract the reference element
     // AKA child.first
@@ -244,15 +261,16 @@ var Popunder = _react2.default.createClass({
           ref: function ref(c) {
             return _this._portal = c;
           },
-          closeOnEsc: closeOnEsc,
-          openByClickOn: openByClickOn,
-          onOpen: this.onOpen,
           beforeClose: beforeClose,
+          isOpened: isOpened,
+          onOpen: this.onOpen,
           onClose: this.onClose,
           onUpdate: onUpdate },
         _react2.default.createElement(
           'div',
-          { ref: 'container', className: _popunder2.default.container, style: position },
+          { ref: function ref(c) {
+              return _this._container = c;
+            }, className: _popunder2.default.container, style: position },
           children.slice(1)
         )
       )

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-dnd-html5-backend": "2.1.2",
     "react-dropzone": "^3.5.0",
     "react-immutable-proptypes": "^1.7.1",
-    "react-portal": "2.1.3",
+    "react-portal": "^2.2.1",
     "react-textarea-autosize": "^4.0.2",
     "scribe-editor": "^3.2.0",
     "shallow-equals": "0.0.0",

--- a/src/components/fields/multi-selection-field/index.js
+++ b/src/components/fields/multi-selection-field/index.js
@@ -80,7 +80,8 @@ const SelectionField = React.createClass({
    */
   getInitialState () {
     return {
-      search: null
+      search: null,
+      searchFocus: false,
     }
   },
 
@@ -195,10 +196,32 @@ const SelectionField = React.createClass({
     })
   },
 
+  /**
+   * On search input focus
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchFocus (e) {
+    this.setState({
+      searchFocus: true
+    })
+  },
+
+  /**
+   * On search input blur
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchBlur (e) {
+    this.setState({
+      searchFocus: false
+    })
+  },
+
   render () {
-    const { attributes, config, errors, hint, label, name, value } = this.props
-    const { instanceKey, search } = this.state
-    const { options, placeholder, selector_label, render_selection_as, render_option_as } = attributes
+    const {attributes, config, errors, hint, label, name, value} = this.props
+    const {instanceKey, search, searchFocus} = this.state
+    const {options, placeholder, selector_label, render_selection_as, render_option_as} = attributes
     const hasErrors = (errors.count() > 0)
 
     // Set up field classes
@@ -283,7 +306,7 @@ const SelectionField = React.createClass({
                   {(numberOfSelections > 0) ? ` (${numberOfSelections} selected)` : null}
                 </div>
               </div>
-              <Popout ref={(c) => this._selector = c} placement='left' onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnOutsideClick>
+              <Popout ref={(c) => this._selector = c} placement='left' onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnEsc={!searchFocus || !search} closeOnOutsideClick>
                 <div className={styles.openSelectorButton}>
                   {selector_label || 'Select'}
                 </div>
@@ -293,6 +316,8 @@ const SelectionField = React.createClass({
                     type='search'
                     className={styles.search}
                     placeholder='Type to filter'
+                    onBlur={this.onSearchBlur}
+                    onFocus={this.onSearchFocus}
                     onChange={this.onSearchChange} />
                   <div className={styles.optionsList}>
                     {renderedOptions.length > 0 ? renderedOptions : <p className={styles.noResults}>No matching results</p>}

--- a/src/components/fields/selection-field/index.js
+++ b/src/components/fields/selection-field/index.js
@@ -43,7 +43,6 @@ SelectDefault.propTypes = {
  *
  */
 const SelectionField = React.createClass({
-
   propTypes: {
     actions: React.PropTypes.object,
     name: React.PropTypes.string,
@@ -81,7 +80,8 @@ const SelectionField = React.createClass({
    */
   getInitialState () {
     return {
-      search: null
+      search: null,
+      searchFocus: false,
     }
   },
 
@@ -180,10 +180,32 @@ const SelectionField = React.createClass({
     })
   },
 
+  /**
+   * On search input focus
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchFocus (e) {
+    this.setState({
+      searchFocus: true
+    })
+  },
+
+  /**
+   * On search input blur
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSearchBlur (e) {
+    this.setState({
+      searchFocus: false
+    })
+  },
+
   render () {
-    const { attributes, config, errors, hint, label, name, value } = this.props
-    const { search } = this.state
-    const { options, placeholder, selector_label, render_option_as, render_selection_as } = attributes
+    const {attributes, config, errors, hint, label, name, value} = this.props
+    const {search, searchFocus} = this.state
+    const {options, placeholder, selector_label, render_option_as, render_selection_as} = attributes
     const hasErrors = (errors.count() > 0)
 
     // Set up field classes
@@ -261,7 +283,7 @@ const SelectionField = React.createClass({
               <div className={styles.selectionPlaceholder}>
                 {placeholder || 'Make a selection'}
               </div>
-              <Popout ref={(c) => this._selector = c} placement='left' closeOnEsc onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnOutsideClick>
+              <Popout ref={(c) => this._selector = c} placement='left' closeOnEsc onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnEsc={!searchFocus || !search} closeOnOutsideClick>
                 <div className={styles.openSelectorButton}>
                   {selector_label || 'Select'}
                 </div>
@@ -271,6 +293,8 @@ const SelectionField = React.createClass({
                     type='search'
                     className={styles.search}
                     placeholder='Type to filter'
+                    onBlur={this.onSearchBlur}
+                    onFocus={this.onSearchFocus}
                     onChange={this.onSearchChange} />
                   <div className={styles.optionsList}>
                     {renderedOptions.length > 0 ? renderedOptions : <p className={styles.noResults}>No matching results</p>}

--- a/src/components/ui/modal/index.js
+++ b/src/components/ui/modal/index.js
@@ -13,21 +13,25 @@ import styles from './modal.mcss'
  * @method getContainer
  */
 const Modal = React.createClass({
-  isOpened: false,
-
   propTypes: {
     beforeClose: React.PropTypes.func,
     children: React.PropTypes.node,
     closeOnEsc: React.PropTypes.bool,
     closeOnOutsideClick: React.PropTypes.bool,
-    openByClickOn: React.PropTypes.node,
     onOpen: React.PropTypes.func,
     onClose: React.PropTypes.func,
     onUpdate: React.PropTypes.func
   },
 
+  getInitialState () {
+    return {
+      isOpened: false,
+    }
+  },
+
   componentWillMount () {
     const {closeOnOutsideClick} = this.props
+    document.addEventListener('keydown', this.handleKeydown)
     if (closeOnOutsideClick) {
       document.addEventListener('mouseup', this.handleOutsideMouseClick)
       document.addEventListener('touchstart', this.handleOutsideMouseClick)
@@ -36,6 +40,7 @@ const Modal = React.createClass({
 
   componentWillUnmount () {
     const {closeOnOutsideClick} = this.props
+    document.removeEventListener('keydown', this.handleKeydown)
     if (closeOnOutsideClick) {
       document.removeEventListener('mouseup', this.handleOutsideMouseClick)
       document.removeEventListener('touchstart', this.handleOutsideMouseClick)
@@ -46,14 +51,18 @@ const Modal = React.createClass({
    * Public interface: Opens the `Portal`
    */
   openModal () {
-    this._portal.openPortal()
+    this.setState({
+      isOpened: true,
+    })
   },
 
   /**
    * Public: Close the `Portal`
    */
   closeModal () {
-    this._portal.closePortal()
+    this.setState({
+      isOpened: false,
+    })
   },
 
   /**
@@ -76,7 +85,7 @@ const Modal = React.createClass({
    * @return {Null}
    */
   handleOutsideMouseClick (e) {
-    if (!this.isOpened) {
+    if (!this.state.isOpened) {
       return
     }
 
@@ -91,11 +100,22 @@ const Modal = React.createClass({
     }
 
     e.stopPropagation()
-    this._portal.closePortal()
+    this.closeModal()
+  },
+
+  /**
+   * Close portal if escape is pressed
+   * @param  {KeyboardEvent} e
+   */
+  handleKeydown (e) {
+    const {closeOnEsc} = this.props
+    // ESCAPE = 27
+    if (closeOnEsc && e.keyCode === 27 && this.state.isOpened) {
+      this.closePopunder();
+    }
   },
 
   onOpen (portalEl) {
-    this.isOpened = true
     document.body.style.overflow = 'hidden'
     document.body.style.position = 'fixed'
     document.body.style.left = '0'
@@ -129,25 +149,22 @@ const Modal = React.createClass({
   render () {
     // Extract Portal props
     const {
-      closeOnEsc,
-      openByClickOn,
       beforeClose,
-      onUpdate
+      onUpdate,
     } = this.props
-
+    const {isOpened} = this.state
     return (
       <Portal
         ref={(c) => this._portal = c}
-        closeOnEsc={closeOnEsc}
-        openByClickOn={openByClickOn}
-        onOpen={this.onOpen}
         beforeClose={beforeClose}
+        isOpened={isOpened}
+        onOpen={this.onOpen}
         onClose={this.onClose}
         onUpdate={onUpdate}>
         <div ref={(c) => this._container = c} className={styles.container}>
           <button className={styles.close} onClick={this.onCloseClick}>
             <span className={styles.closeText}>Close</span>
-            <div className={styles.closeX}>&times;</div>
+            <div className={styles.closeX}>×</div>
           </button>
           <button className={styles.overlay} onClick={this.onOverlayClick} />
           <div className={styles.content}>


### PR DESCRIPTION
The `react-portal` library seems a little *fussy* wrt keeping track if its DOM nodes if you’re using `refs`. This removes any dependency on the ref for open/close behaviour, instead relying entirely on data passed through `props`, which means we can control it properly.