### PR TITLE
Search selection fields

### DIFF
--- a/lib/components/fields/index.js
+++ b/lib/components/fields/index.js
@@ -46,6 +46,10 @@ var _searchSelectionField = require('./search-selection-field');
 
 var _searchSelectionField2 = _interopRequireDefault(_searchSelectionField);
 
+var _searchMultiSelectionField = require('./search-multi-selection-field');
+
+var _searchMultiSelectionField2 = _interopRequireDefault(_searchMultiSelectionField);
+
 var _selectBox = require('./select-box');
 
 var _selectBox2 = _interopRequireDefault(_selectBox);
@@ -105,6 +109,7 @@ function fields() {
     numberField: wrapField(_numberField2.default, fieldsConfig.numberField, globalConfig),
     radioButtons: wrapField(_radioButtons2.default, fieldsConfig.radioButtons, globalConfig),
     searchSelectionField: wrapField(_searchSelectionField2.default, fieldsConfig.searchSelectionField, globalConfig),
+    searchMultiSelectionField: wrapField(_searchMultiSelectionField2.default, fieldsConfig.searchMultiSelectionField, globalConfig),
     selectBox: wrapField(_selectBox2.default, fieldsConfig.selectBox, globalConfig),
     selectionField: wrapField(_selectionField2.default, fieldsConfig.selectionField, globalConfig),
     textArea: wrapField(_textArea2.default, fieldsConfig.textArea, globalConfig),

--- a/lib/components/fields/index.js
+++ b/lib/components/fields/index.js
@@ -42,6 +42,10 @@ var _radioButtons = require('./radio-buttons');
 
 var _radioButtons2 = _interopRequireDefault(_radioButtons);
 
+var _searchSelectionField = require('./search-selection-field');
+
+var _searchSelectionField2 = _interopRequireDefault(_searchSelectionField);
+
 var _selectBox = require('./select-box');
 
 var _selectBox2 = _interopRequireDefault(_selectBox);
@@ -100,6 +104,7 @@ function fields() {
     multiSelectionField: wrapField(_multiSelectionField2.default, fieldsConfig.multiSelectionField, globalConfig),
     numberField: wrapField(_numberField2.default, fieldsConfig.numberField, globalConfig),
     radioButtons: wrapField(_radioButtons2.default, fieldsConfig.radioButtons, globalConfig),
+    searchSelectionField: wrapField(_searchSelectionField2.default, fieldsConfig.searchSelectionField, globalConfig),
     selectBox: wrapField(_selectBox2.default, fieldsConfig.selectBox, globalConfig),
     selectionField: wrapField(_selectionField2.default, fieldsConfig.selectionField, globalConfig),
     textArea: wrapField(_textArea2.default, fieldsConfig.textArea, globalConfig),

--- a/lib/components/fields/multi-selection-field/index.js
+++ b/lib/components/fields/multi-selection-field/index.js
@@ -289,7 +289,6 @@ var SelectionField = _react2.default.createClass({
     var name = _props.name;
     var value = _props.value;
     var _state = this.state;
-    var instanceKey = _state.instanceKey;
     var search = _state.search;
     var searchFocus = _state.searchFocus;
     var options = attributes.options;
@@ -433,7 +432,7 @@ var SelectionField = _react2.default.createClass({
             _sortable2.default,
             { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop },
             selections.map(function (option, index) {
-              return _react2.default.createElement(Selection, { key: instanceKey + '_' + index + '_' + option.id, option: option });
+              return _react2.default.createElement(Selection, { key: index + '_' + option.id, option: option });
             })
           )
         ) : null,

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -18,6 +18,8 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
+var _immutable = require('immutable');
+
 var _extractComponent = require('../../../utils/extract-component');
 
 var _extractComponent2 = _interopRequireDefault(_extractComponent);
@@ -30,6 +32,10 @@ var _header = require('../common/header');
 
 var _header2 = _interopRequireDefault(_header);
 
+var _sortable = require('../../ui/sortable');
+
+var _sortable2 = _interopRequireDefault(_sortable);
+
 var _popout = require('../../ui/popout');
 
 var _popout2 = _interopRequireDefault(_popout);
@@ -38,9 +44,9 @@ var _searchSelector = require('../../ui/search-selector');
 
 var _searchSelector2 = _interopRequireDefault(_searchSelector);
 
-var _searchSelectionField = require('./search-selection-field.mcss');
+var _searchMultiSelectionField = require('./search-multi-selection-field.mcss');
 
-var _searchSelectionField2 = _interopRequireDefault(_searchSelectionField);
+var _searchMultiSelectionField2 = _interopRequireDefault(_searchMultiSelectionField);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -92,18 +98,18 @@ SelectDefault.propTypes = {
  *
  */
 
-var SearchSelectionField = function (_Component) {
-  _inherits(SearchSelectionField, _Component);
+var SearchMultiSelectionField = function (_Component) {
+  _inherits(SearchMultiSelectionField, _Component);
 
-  function SearchSelectionField(props) {
-    _classCallCheck(this, SearchSelectionField);
+  function SearchMultiSelectionField(props) {
+    _classCallCheck(this, SearchMultiSelectionField);
 
     // Initial state
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SearchSelectionField).call(this, props));
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SearchMultiSelectionField).call(this, props));
 
     _this.state = {
-      selection: props.selection,
+      selections: props.selections,
       selectorFocus: false,
       selectorQuery: null
     };
@@ -111,8 +117,9 @@ var SearchSelectionField = function (_Component) {
     // Bindings
     _this.onChange = _this.onChange.bind(_this);
     _this.onChooseClick = _this.onChooseClick.bind(_this);
-    _this.onRemoveClick = _this.onRemoveClick.bind(_this);
     _this.onSelection = _this.onSelection.bind(_this);
+    _this.onRemove = _this.onRemove.bind(_this);
+    _this.onDrop = _this.onDrop.bind(_this);
     _this.openSelector = _this.openSelector.bind(_this);
     _this.closeSelector = _this.closeSelector.bind(_this);
     _this.toggleSelector = _this.toggleSelector.bind(_this);
@@ -130,14 +137,14 @@ var SearchSelectionField = function (_Component) {
    */
 
 
-  _createClass(SearchSelectionField, [{
+  _createClass(SearchMultiSelectionField, [{
     key: 'onChange',
-    value: function onChange(value, selection) {
+    value: function onChange(values, selections) {
       this.props.actions.edit(function (val) {
-        return value;
+        return values;
       });
       this.setState({
-        selection: selection
+        selections: selections
       });
     }
 
@@ -155,14 +162,36 @@ var SearchSelectionField = function (_Component) {
 
     /**
      * When selected item is removed
+     * @param {Number} index Index of the item to remove
      * @return {Null}
      */
 
   }, {
-    key: 'onRemoveClick',
-    value: function onRemoveClick(e) {
-      e.preventDefault();
-      this.onChange(null, null);
+    key: 'onRemove',
+    value: function onRemove(index) {
+      var value = this.props.value;
+      var selections = this.state.selections;
+
+      this.onChange(value.delete(index), selections.delete(index));
+    }
+
+    /**
+     * When selected item is removed
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onDrop',
+    value: function onDrop(newOrder) {
+      var value = this.props.value.slice();
+      var selections = this.state.selections.slice();
+      var updatedValue = newOrder.map(function (index) {
+        return value.get(index);
+      });
+      var updatedSelections = newOrder.map(function (index) {
+        return selections.get(index);
+      });
+      this.onChange((0, _immutable.List)(updatedValue), (0, _immutable.List)(updatedSelections));
     }
 
     /**
@@ -173,8 +202,18 @@ var SearchSelectionField = function (_Component) {
   }, {
     key: 'onSelection',
     value: function onSelection(id, selection) {
-      this.closeSelector();
-      this.onChange(id, selection);
+      var value = this.props.value;
+
+      value = value || (0, _immutable.List)();
+      // Exists already? Remove it
+      var index = value.indexOf(id);
+      if (index > -1) {
+        this.onRemove(index);
+      } else {
+        var selections = this.state.selections;
+
+        this.onChange(value.push(id), selections.push(selection));
+      }
     }
 
     /**
@@ -273,14 +312,14 @@ var SearchSelectionField = function (_Component) {
       var render_option_as = attributes.render_option_as;
       var render_selection_as = attributes.render_selection_as;
       var _state = this.state;
-      var selection = _state.selection;
+      var selections = _state.selections;
       var selectorFocus = _state.selectorFocus;
       var selectorQuery = _state.selectorQuery;
 
       var hasErrors = errors.count() > 0;
 
       // Set up field classes
-      var fieldClassNames = (0, _classnames2.default)(_searchSelectionField2.default.base, _defineProperty({}, '' + _searchSelectionField2.default.baseInline, attributes.inline));
+      var fieldClassNames = (0, _classnames2.default)(_searchMultiSelectionField2.default.base, _defineProperty({}, '' + _searchMultiSelectionField2.default.baseInline, attributes.inline));
 
       // Determine the selection/selected display components
       var Option = SelectDefault;
@@ -296,46 +335,28 @@ var SearchSelectionField = function (_Component) {
         }
       }
 
+      // Selections
+      var numberOfSelections = selections.count();
+
       return _react2.default.createElement(
         'div',
         { className: fieldClassNames },
         _react2.default.createElement(
           'div',
-          { className: _searchSelectionField2.default.header },
+          { className: _searchMultiSelectionField2.default.header },
           _react2.default.createElement(_header2.default, { id: name, label: label, hint: hint, error: hasErrors })
         ),
         _react2.default.createElement(
           'div',
-          { className: _searchSelectionField2.default.display },
-          selection ? _react2.default.createElement(
-            'div',
-            { className: _searchSelectionField2.default.wrapper },
-            _react2.default.createElement(
-              'div',
-              { id: name, className: _searchSelectionField2.default.selection },
-              _react2.default.createElement(Selection, { option: selection })
-            ),
-            _react2.default.createElement(
-              'button',
-              { className: _searchSelectionField2.default.remove, onClick: this.onRemoveClick },
-              _react2.default.createElement(
-                'span',
-                { className: _searchSelectionField2.default.removeText },
-                'Remove'
-              ),
-              _react2.default.createElement(
-                'div',
-                { className: _searchSelectionField2.default.removeX },
-                '×'
-              )
-            )
-          ) : _react2.default.createElement(
+          { className: _searchMultiSelectionField2.default.display },
+          _react2.default.createElement(
             'button',
-            { className: _searchSelectionField2.default.wrapper, onClick: this.onChooseClick },
+            { className: _searchMultiSelectionField2.default.wrapper, onClick: this.onChooseClick },
             _react2.default.createElement(
               'div',
-              { className: _searchSelectionField2.default.selectionPlaceholder },
-              placeholder || 'Make a selection'
+              { className: _searchMultiSelectionField2.default.selectionPlaceholder },
+              placeholder || 'Make a selection',
+              numberOfSelections > 0 ? ' (' + numberOfSelections + ' selected)' : null
             ),
             _react2.default.createElement(
               _popout2.default,
@@ -344,7 +365,7 @@ var SearchSelectionField = function (_Component) {
                 }, placement: 'left', onClose: this.onPopoutClose, onOpen: this.onPopoutOpen, closeOnEsc: !selectorFocus || !selectorQuery, closeOnOutsideClick: true },
               _react2.default.createElement(
                 'div',
-                { className: _searchSelectionField2.default.openSelectorButton },
+                { className: _searchMultiSelectionField2.default.openSelectorButton },
                 selector_label || 'Select'
               ),
               _react2.default.createElement(_searchSelector2.default, {
@@ -359,17 +380,29 @@ var SearchSelectionField = function (_Component) {
                 params: attributes.search_params,
                 perPage: attributes.search_per_page,
                 query: selectorQuery,
+                selectedIds: value ? value.toJS() : [],
                 threshold: attributes.search_threshold,
                 url: attributes.search_url })
             )
-          ),
-          hasErrors ? _react2.default.createElement(_errors2.default, { errors: errors }) : null
-        )
+          )
+        ),
+        numberOfSelections > 0 ? _react2.default.createElement(
+          'div',
+          { id: name, className: _searchMultiSelectionField2.default.selectedItems },
+          _react2.default.createElement(
+            _sortable2.default,
+            { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop },
+            selections.map(function (option, index) {
+              return _react2.default.createElement(Selection, { key: index + '_' + option.id, option: option });
+            })
+          )
+        ) : null,
+        hasErrors ? _react2.default.createElement(_errors2.default, { errors: errors }) : null
       );
     }
   }]);
 
-  return SearchSelectionField;
+  return SearchMultiSelectionField;
 }(_react.Component);
 
 /**
@@ -377,7 +410,7 @@ var SearchSelectionField = function (_Component) {
  */
 
 
-SearchSelectionField.contextTypes = {
+SearchMultiSelectionField.contextTypes = {
   globalConfig: _react2.default.PropTypes.object
 };
 
@@ -385,7 +418,7 @@ SearchSelectionField.contextTypes = {
  * PropTypes
  * @type {Object}
  */
-SearchSelectionField.propTypes = {
+SearchMultiSelectionField.propTypes = {
   actions: _react2.default.PropTypes.object,
   name: _react2.default.PropTypes.string,
   config: _react2.default.PropTypes.object,
@@ -394,6 +427,7 @@ SearchSelectionField.propTypes = {
     hint: _react2.default.PropTypes.string,
     placeholder: _react2.default.PropTypes.string,
     inline: _react2.default.PropTypes.bool,
+    selections: _reactImmutableProptypes2.default.list,
     search_url: _react2.default.PropTypes.string,
     search_per_page: _react2.default.PropTypes.number,
     search_params: _react2.default.PropTypes.object,
@@ -405,7 +439,11 @@ SearchSelectionField.propTypes = {
   hint: _react2.default.PropTypes.string,
   label: _react2.default.PropTypes.string,
   errors: _reactImmutableProptypes2.default.list,
-  value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number])
+  value: _reactImmutableProptypes2.default.list
 };
 
-exports.default = SearchSelectionField;
+SearchMultiSelectionField.defaultProps = {
+  selections: (0, _immutable.List)()
+};
+
+exports.default = SearchMultiSelectionField;

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -104,12 +104,16 @@ var SearchMultiSelectionField = function (_Component) {
   function SearchMultiSelectionField(props) {
     _classCallCheck(this, SearchMultiSelectionField);
 
-    // Initial state
+    // Keep as a property so can always know the "true" set
 
     var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SearchMultiSelectionField).call(this, props));
 
+    _this.cachedSelections = props.selections;
+    _this.cachedValue = props.value;
+
+    // Initial state
     _this.state = {
-      selections: props.selections,
+      selections: _this.cachedSelections,
       selectorFocus: false,
       selectorQuery: null
     };
@@ -130,18 +134,25 @@ var SearchMultiSelectionField = function (_Component) {
     return _this;
   }
 
-  /**
-   * onChange handler
-   *
-   * @param  {Event} e Change event from a form input/select
-   */
-
-
   _createClass(SearchMultiSelectionField, [{
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(nextProps) {
+      this.cachedValue = nextProps.value;
+    }
+
+    /**
+     * onChange handler
+     *
+     * @param  {Event} e Change event from a form input/select
+     */
+
+  }, {
     key: 'onChange',
-    value: function onChange(values, selections) {
+    value: function onChange(value, selections) {
+      this.cachedValue = value;
+      this.cachedSelections = selections;
       this.props.actions.edit(function (val) {
-        return values;
+        return value;
       });
       this.setState({
         selections: selections
@@ -169,10 +180,7 @@ var SearchMultiSelectionField = function (_Component) {
   }, {
     key: 'onRemove',
     value: function onRemove(index) {
-      var value = this.props.value;
-      var selections = this.state.selections;
-
-      this.onChange(value.delete(index), selections.delete(index));
+      this.onChange(this.cachedValue.delete(index), this.cachedSelections.delete(index));
     }
 
     /**
@@ -183,8 +191,8 @@ var SearchMultiSelectionField = function (_Component) {
   }, {
     key: 'onDrop',
     value: function onDrop(newOrder) {
-      var value = this.props.value.slice();
-      var selections = this.state.selections.slice();
+      var value = this.cachedValue.slice();
+      var selections = this.cachedSelections.slice();
       var updatedValue = newOrder.map(function (index) {
         return value.get(index);
       });
@@ -202,17 +210,14 @@ var SearchMultiSelectionField = function (_Component) {
   }, {
     key: 'onSelection',
     value: function onSelection(id, selection) {
-      var value = this.props.value;
-
+      var value = this.cachedValue;
       value = value || (0, _immutable.List)();
       // Exists already? Remove it
       var index = value.indexOf(id);
       if (index > -1) {
         this.onRemove(index);
       } else {
-        var selections = this.state.selections;
-
-        this.onChange(value.push(id), selections.push(selection));
+        this.onChange(value.push(id), this.cachedSelections.push(selection));
       }
     }
 

--- a/lib/components/fields/search-multi-selection-field/search-multi-selection-field.mcss
+++ b/lib/components/fields/search-multi-selection-field/search-multi-selection-field.mcss
@@ -47,6 +47,7 @@
   margin-bottom: -0.4rem;
 }
 
+
 /**
  * Selections
  */
@@ -85,7 +86,7 @@
   }
 
 .optionButton {
-  composes: normal sans greyTintBorder whiteBackground from styles;
+  composes: small sans greyTintBorder whiteBackground from styles;
   border-width: 0;
   border-bottom-width: 1px;
   border-style: solid;
@@ -107,4 +108,3 @@
 .optionButton em {
   font-style: italic;
 }
-

--- a/lib/components/fields/search-selection-field/index.js
+++ b/lib/components/fields/search-selection-field/index.js
@@ -1,0 +1,415 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactImmutableProptypes = require('react-immutable-proptypes');
+
+var _reactImmutableProptypes2 = _interopRequireDefault(_reactImmutableProptypes);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _fuzzy = require('fuzzy');
+
+var _fuzzy2 = _interopRequireDefault(_fuzzy);
+
+var _extractComponent = require('../../../utils/extract-component');
+
+var _extractComponent2 = _interopRequireDefault(_extractComponent);
+
+var _errors = require('../common/errors');
+
+var _errors2 = _interopRequireDefault(_errors);
+
+var _header = require('../common/header');
+
+var _header2 = _interopRequireDefault(_header);
+
+var _popout = require('../../ui/popout');
+
+var _popout2 = _interopRequireDefault(_popout);
+
+var _searchSelector = require('../../ui/search-selector');
+
+var _searchSelector2 = _interopRequireDefault(_searchSelector);
+
+var _searchSelectionField = require('./search-selection-field.mcss');
+
+var _searchSelectionField2 = _interopRequireDefault(_searchSelectionField);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+// Import components
+
+
+// Import styles
+
+
+/**
+ * Default component for representing a "selected/selection" item
+ * @param  {Object} props Taking the shape of:
+ *
+ * {
+ *   option: { label: 'foo'}
+ *  }
+ *
+ * I.e., expecting the option to have a `label` key with a string value.
+ *
+ * @return {ReactElement}
+ */
+var SelectDefault = function SelectDefault(_ref) {
+  var option = _ref.option;
+  return _react2.default.createElement(
+    'div',
+    null,
+    option.label
+  );
+};
+
+SelectDefault.propTypes = {
+  option: _react2.default.PropTypes.shape({
+    label: _react2.default.PropTypes.string
+  })
+};
+
+/**
+ * Search Selection field
+ *
+ * Handles the singular select of a
+ *
+ */
+
+var SearchSelectionField = function (_Component) {
+  _inherits(SearchSelectionField, _Component);
+
+  function SearchSelectionField(props) {
+    _classCallCheck(this, SearchSelectionField);
+
+    // Initial state
+
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SearchSelectionField).call(this, props));
+
+    _this.state = {
+      selection: props.selection,
+      selectorFocus: false,
+      selectorQuery: null
+    };
+
+    // Bindings
+    _this.onChange = _this.onChange.bind(_this);
+    _this.onChooseClick = _this.onChooseClick.bind(_this);
+    _this.onRemoveClick = _this.onRemoveClick.bind(_this);
+    _this.onSelection = _this.onSelection.bind(_this);
+    _this.openSelector = _this.openSelector.bind(_this);
+    _this.closeSelector = _this.closeSelector.bind(_this);
+    _this.toggleSelector = _this.toggleSelector.bind(_this);
+    _this.onPopoutOpen = _this.onPopoutOpen.bind(_this);
+    _this.onSelectorBlur = _this.onSelectorBlur.bind(_this);
+    _this.onSelectorFocus = _this.onSelectorFocus.bind(_this);
+    _this.onSelectorQueryChange = _this.onSelectorQueryChange.bind(_this);
+    return _this;
+  }
+
+  /**
+   * onChange handler
+   *
+   * @param  {Event} e Change event from a form input/select
+   */
+
+
+  _createClass(SearchSelectionField, [{
+    key: 'onChange',
+    value: function onChange(value, selection) {
+      this.props.actions.edit(function (val) {
+        return value;
+      });
+      this.setState({
+        selection: selection
+      });
+    }
+
+    /**
+     * On choose click, open selector
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onChooseClick',
+    value: function onChooseClick(e) {
+      e.preventDefault();
+      this.toggleSelector();
+    }
+
+    /**
+     * When selected item is removed
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onRemoveClick',
+    value: function onRemoveClick(e) {
+      e.preventDefault();
+      this.onChange(null, null);
+    }
+
+    /**
+     * When a selection is made, trigger change and close the selector
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onSelection',
+    value: function onSelection(id, selection) {
+      this.closeSelector();
+      this.onChange(id, selection);
+    }
+
+    /**
+     * Open the selector popout
+     * @return {Null}
+     */
+
+  }, {
+    key: 'openSelector',
+    value: function openSelector() {
+      this._popout.openPopout();
+    }
+
+    /**
+     * Close the selector popout
+     * @return {Null}
+     */
+
+  }, {
+    key: 'closeSelector',
+    value: function closeSelector() {
+      this._popout.closePopout();
+    }
+
+    /**
+     * Toggle the selector popout
+     * @return {Null}
+     */
+
+  }, {
+    key: 'toggleSelector',
+    value: function toggleSelector() {
+      this._popout.togglePopout();
+    }
+
+    /**
+     * On popout open, focus the search input
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onPopoutOpen',
+    value: function onPopoutOpen() {
+      this._selector.focusSearch();
+    }
+
+    /**
+     * On selector focus
+     * @param  {Event} e Keyboard event
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onSelectorFocus',
+    value: function onSelectorFocus(e) {
+      this.setState({
+        selectorFocus: true
+      });
+    }
+
+    /**
+     * On selector blur
+     * @param  {Event} e Keyboard event
+     * @return {Null}
+     */
+
+  }, {
+    key: 'onSelectorBlur',
+    value: function onSelectorBlur(e) {
+      this.setState({
+        selectorFocus: false
+      });
+    }
+  }, {
+    key: 'onSelectorQueryChange',
+    value: function onSelectorQueryChange(selectorQuery) {
+      this.setState({
+        selectorQuery: selectorQuery
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
+
+      var _props = this.props;
+      var attributes = _props.attributes;
+      var config = _props.config;
+      var errors = _props.errors;
+      var hint = _props.hint;
+      var label = _props.label;
+      var name = _props.name;
+      var value = _props.value;
+      var placeholder = attributes.placeholder;
+      var selector_label = attributes.selector_label;
+      var render_option_as = attributes.render_option_as;
+      var render_selection_as = attributes.render_selection_as;
+      var _state = this.state;
+      var selection = _state.selection;
+      var selectorFocus = _state.selectorFocus;
+      var selectorQuery = _state.selectorQuery;
+
+      var hasErrors = errors.count() > 0;
+
+      // Set up field classes
+      var fieldClassNames = (0, _classnames2.default)(_searchSelectionField2.default.base, _defineProperty({}, '' + _searchSelectionField2.default.baseInline, attributes.inline));
+
+      // Determine the selection/selected display components
+      var Option = SelectDefault;
+      var Selection = SelectDefault;
+
+      // Extract them from the passed `config.components` if it exists
+      if (config.components) {
+        if (render_option_as) {
+          Option = (0, _extractComponent2.default)(config.components, render_option_as) || Option;
+        }
+        if (render_selection_as) {
+          Selection = (0, _extractComponent2.default)(config.components, render_selection_as) || Selection;
+        }
+      }
+
+      return _react2.default.createElement(
+        'div',
+        { className: fieldClassNames },
+        _react2.default.createElement(
+          'div',
+          { className: _searchSelectionField2.default.header },
+          _react2.default.createElement(_header2.default, { id: name, label: label, hint: hint, error: hasErrors })
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: _searchSelectionField2.default.display },
+          selection ? _react2.default.createElement(
+            'div',
+            { className: _searchSelectionField2.default.wrapper },
+            _react2.default.createElement(
+              'div',
+              { id: name, className: _searchSelectionField2.default.selection },
+              _react2.default.createElement(Selection, { option: selection })
+            ),
+            _react2.default.createElement(
+              'button',
+              { className: _searchSelectionField2.default.remove, onClick: this.onRemoveClick },
+              _react2.default.createElement(
+                'span',
+                { className: _searchSelectionField2.default.removeText },
+                'Remove'
+              ),
+              _react2.default.createElement(
+                'div',
+                { className: _searchSelectionField2.default.removeX },
+                '×'
+              )
+            )
+          ) : _react2.default.createElement(
+            'button',
+            { className: _searchSelectionField2.default.wrapper, onClick: this.onChooseClick },
+            _react2.default.createElement(
+              'div',
+              { className: _searchSelectionField2.default.selectionPlaceholder },
+              placeholder || 'Make a selection'
+            ),
+            _react2.default.createElement(
+              _popout2.default,
+              { ref: function ref(r) {
+                  return _this2._popout = r;
+                }, placement: 'left', onClose: this.onPopoutClose, onOpen: this.onPopoutOpen, closeOnEsc: !selectorFocus || !selectorQuery, closeOnOutsideClick: true },
+              _react2.default.createElement(
+                'div',
+                { className: _searchSelectionField2.default.openSelectorButton },
+                selector_label || 'Select'
+              ),
+              _react2.default.createElement(_searchSelector2.default, {
+                ref: function ref(r) {
+                  return _this2._selector = r;
+                },
+                onSelection: this.onSelection,
+                onBlur: this.onSelectorBlur,
+                onFocus: this.onSelectorFocus,
+                onQueryChange: this.onSelectorQueryChange,
+                optionComponent: Option,
+                params: attributes.search_params,
+                perPage: attributes.search_per_page,
+                query: selectorQuery,
+                threshold: attributes.search_threshold,
+                url: attributes.search_url })
+            )
+          ),
+          hasErrors ? _react2.default.createElement(_errors2.default, { errors: errors }) : null
+        )
+      );
+    }
+  }]);
+
+  return SearchSelectionField;
+}(_react.Component);
+
+/**
+ * Enable parent to pass context
+ */
+
+
+SearchSelectionField.contextTypes = {
+  globalConfig: _react2.default.PropTypes.object
+};
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+SearchSelectionField.propTypes = {
+  actions: _react2.default.PropTypes.object,
+  name: _react2.default.PropTypes.string,
+  config: _react2.default.PropTypes.object,
+  attributes: _react2.default.PropTypes.shape({
+    label: _react2.default.PropTypes.string,
+    hint: _react2.default.PropTypes.string,
+    placeholder: _react2.default.PropTypes.string,
+    inline: _react2.default.PropTypes.bool,
+    search_url: _react2.default.PropTypes.string,
+    search_per_page: _react2.default.PropTypes.number,
+    search_params: _react2.default.PropTypes.object,
+    search_threshold: _react2.default.PropTypes.number,
+    selector_label: _react2.default.PropTypes.string,
+    render_option_as: _react2.default.PropTypes.string,
+    render_selection_as: _react2.default.PropTypes.string
+  }),
+  hint: _react2.default.PropTypes.string,
+  label: _react2.default.PropTypes.string,
+  errors: _reactImmutableProptypes2.default.list,
+  value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number])
+};
+
+exports.default = SearchSelectionField;

--- a/lib/components/fields/search-selection-field/search-selection-field.mcss
+++ b/lib/components/fields/search-selection-field/search-selection-field.mcss
@@ -1,0 +1,135 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error, fontSansBoldWeight, highlightLight: from styles;
+
+.base {
+  composes: base from '../shared.mcss';
+}
+  .baseInline {
+    composes: baseInline from '../shared.mcss';
+  }
+
+.display {
+  composes: inputBox from '../../ui/input-boxes.mcss';
+}
+
+/**
+ *
+ */
+
+.wrapper {
+  align-items: center;
+  display: flex;
+  padding: 0;
+  width: 100%;
+}
+  .wrapper:focus {
+    outline: none;
+  }
+
+.selection {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  text-align: left;
+  min-height: 2rem;
+}
+
+.selectionPlaceholder {
+  composes: selection;
+  composes: greyMidColor normal sans from styles;
+}
+
+.openSelectorButton {
+  composes: small buttonHighlight from '../../ui/buttons.mcss';
+  margin-right: -0.3rem;
+  margin-top: -0.2rem;
+  margin-bottom: -0.4rem;
+}
+
+/* Selection exists */
+
+.remove {
+  composes: primaryColor from styles;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.17em;
+  margin-top: -0.3rem;
+  margin-bottom: -0.3rem;
+  transition-property: color;
+  transition-duration: 100ms;
+}
+  .remove:focus,
+  .remove:hover {
+    color: error;
+  }
+
+.removeText {
+  display: none;
+}
+
+.removeX {
+  composes: fallback large from styles;
+}
+
+/**
+ * Selections
+ */
+
+.options {
+  min-width: 30rem;
+}
+
+.optionsList {
+  max-height: 40rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  padding-top: 0.5rem;
+}
+
+.noResults {
+  composes: normal sans from styles;
+  padding: 0.5em 1rem 0.7em;
+}
+
+.search {
+  composes: normal sans greyTintBorder from styles;
+  appearance: none;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  box-sizing: border-box;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
+  padding: 0.5em 0.5em 0.7em 0.5em;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+  .search:focus {
+    outline: none;
+  }
+
+.optionButton {
+  composes: small sans greyTintBorder whiteBackground from styles;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-style: solid;
+  cursor: pointer;
+  display: block;
+  padding: 0.7rem 1rem;
+  text-align: left;
+  width: 100%;
+}
+  .optionButton:hover {
+    text-decoration: underline;
+  }
+
+.selection strong,
+.optionButton strong {
+  font-weight: fontSansBoldWeight;
+}
+.selection em,
+.optionButton em {
+  font-style: italic;
+}

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -67,6 +67,7 @@ var SearchSelector = function (_Component) {
 
     // Default state
     _this.state = {
+      hasSearched: false,
       loading: false,
       results: [],
       pagination: {}
@@ -125,13 +126,15 @@ var SearchSelector = function (_Component) {
         this.currentRequest = req;
 
         this.setState({
-          loading: true
+          loading: true,
+          hasSearched: true
         });
       } else {
         this.setState({
           loading: false,
           results: [],
-          pagination: {}
+          pagination: {},
+          hasSearched: true
         });
       }
     }
@@ -190,6 +193,7 @@ var SearchSelector = function (_Component) {
       var optionComponent = _props3.optionComponent;
       var selectedIds = _props3.selectedIds;
       var _state = this.state;
+      var hasSearched = _state.hasSearched;
       var loading = _state.loading;
       var results = _state.results;
       var pagination = _state.pagination;
@@ -247,7 +251,7 @@ var SearchSelector = function (_Component) {
             { className: _searchSelector2.default.list },
             options
           )
-        ) : hasQuery && !loading ? _react2.default.createElement(
+        ) : hasSearched && hasQuery && !loading ? _react2.default.createElement(
           'p',
           { className: _searchSelector2.default.noResults },
           'No results matching your search'

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -1,0 +1,293 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _lodash = require('lodash.debounce');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _search = require('./search');
+
+var _search2 = _interopRequireDefault(_search);
+
+var _pagination = require('./pagination');
+
+var _pagination2 = _interopRequireDefault(_pagination);
+
+var _spinner = require('../spinner');
+
+var _spinner2 = _interopRequireDefault(_spinner);
+
+var _searchSelector = require('./search-selector.mcss');
+
+var _searchSelector2 = _interopRequireDefault(_searchSelector);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function abortCurrentSearch(req) {
+  if (req && req.abort) {
+    req.abort();
+  }
+}
+
+var SearchSelector = function (_Component) {
+  _inherits(SearchSelector, _Component);
+
+  function SearchSelector(props) {
+    _classCallCheck(this, SearchSelector);
+
+    // Instance vars
+
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(SearchSelector).call(this, props));
+
+    _this.page = 1;
+    _this.query = props.query;
+    // Persistent request object
+    _this.currentRequest = null;
+
+    // Default state
+    _this.state = {
+      loading: false,
+      results: [],
+      pagination: {}
+    };
+
+    // Bindings
+    _this.doSearch = (0, _lodash2.default)(_this.doSearch.bind(_this), 250);
+    _this.onSearchChange = _this.onSearchChange.bind(_this);
+    _this.onSearchSuccess = _this.onSearchSuccess.bind(_this);
+    _this.onSearchBlur = _this.onSearchBlur.bind(_this);
+    _this.onSearchFocus = _this.onSearchFocus.bind(_this);
+    _this.goToPage = _this.goToPage.bind(_this);
+    return _this;
+  }
+
+  _createClass(SearchSelector, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      var _props = this.props;
+      var threshold = _props.threshold;
+      var query = _props.query;
+      // Do a search for nothing on load if threshold is 0
+
+      if (query && query.length >= threshold) {
+        this.doSearch(query);
+      }
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      abortCurrentSearch(this.currentRequest);
+    }
+  }, {
+    key: 'doSearch',
+    value: function doSearch(query) {
+      var _props2 = this.props;
+      var params = _props2.params;
+      var perPage = _props2.perPage;
+      var threshold = _props2.threshold;
+      var url = _props2.url;
+
+      this.query = query != null ? query : this.query;
+      // Abort any existing requests
+      abortCurrentSearch(this.currentRequest);
+
+      // Only search if have enough characters
+      if (this.query.length >= threshold) {
+        // Save the current request
+        var data = Object.assign({}, params, {
+          q: this.query,
+          page: this.page,
+          per_page: perPage
+        });
+        var req = (0, _search2.default)(url, data);
+        req.response.then(this.onSearchSuccess);
+        this.currentRequest = req;
+
+        this.setState({
+          loading: true
+        });
+      } else {
+        this.setState({
+          loading: false,
+          results: [],
+          pagination: {}
+        });
+      }
+    }
+  }, {
+    key: 'onSearchBlur',
+    value: function onSearchBlur(e) {
+      if (this.props.onBlur) {
+        this.props.onBlur(e);
+      }
+    }
+  }, {
+    key: 'onSearchFocus',
+    value: function onSearchFocus(e) {
+      if (this.props.onFocus) {
+        this.props.onFocus(e);
+      }
+    }
+  }, {
+    key: 'onSearchChange',
+    value: function onSearchChange(e) {
+      var query = e.target.value;
+      // Reset page value to default
+      this.page = 1;
+      this.doSearch(query);
+      if (this.props.onQueryChange) {
+        this.props.onQueryChange(query);
+      }
+    }
+  }, {
+    key: 'onSearchSuccess',
+    value: function onSearchSuccess(rsp) {
+      this.setState({
+        loading: false,
+        results: rsp.results,
+        pagination: rsp.pagination
+      });
+    }
+  }, {
+    key: 'goToPage',
+    value: function goToPage(page) {
+      this.page = parseInt(page);
+      this.doSearch();
+    }
+  }, {
+    key: 'focusSearch',
+    value: function focusSearch() {
+      this._search.focus();
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
+
+      var _props3 = this.props;
+      var onSelection = _props3.onSelection;
+      var optionComponent = _props3.optionComponent;
+      var _state = this.state;
+      var loading = _state.loading;
+      var results = _state.results;
+      var pagination = _state.pagination;
+
+      // Has query?
+
+      var hasQuery = this.query != null && this.query !== '';
+
+      // Render each option
+      var Option = optionComponent;
+      var options = results.map(function (option) {
+        var onClick = function (e) {
+          e.preventDefault();
+          onSelection(option.id, option);
+        }.bind(_this2);
+        return _react2.default.createElement(
+          'button',
+          {
+            key: option.id,
+            className: _searchSelector2.default.optionButton,
+            onClick: onClick },
+          _react2.default.createElement(Option, { option: option })
+        );
+      });
+
+      var resultClassNames = (0, _classnames2.default)(_searchSelector2.default.results, _defineProperty({}, '' + _searchSelector2.default.resultsLoading, loading));
+
+      return _react2.default.createElement(
+        'div',
+        { className: _searchSelector2.default.base },
+        _react2.default.createElement('input', {
+          ref: function ref(r) {
+            return _this2._search = r;
+          },
+          type: 'text',
+          className: _searchSelector2.default.search,
+          defaultValue: this.query,
+          placeholder: 'Type to search',
+          onBlur: this.onSearchBlur,
+          onFocus: this.onSearchFocus,
+          onChange: this.onSearchChange }),
+        loading ? _react2.default.createElement(_spinner2.default, { className: _searchSelector2.default.spinner }) : null,
+        options.length > 0 ? _react2.default.createElement(
+          'div',
+          { className: resultClassNames },
+          _react2.default.createElement(
+            'div',
+            { className: _searchSelector2.default.pagination },
+            _react2.default.createElement(_pagination2.default, { currentPage: this.page, totalPages: pagination.total_pages, goToPage: this.goToPage })
+          ),
+          _react2.default.createElement(
+            'div',
+            { className: _searchSelector2.default.list },
+            options
+          )
+        ) : hasQuery && !loading ? _react2.default.createElement(
+          'p',
+          { className: _searchSelector2.default.noResults },
+          'No results matching your search'
+        ) : null
+      );
+    }
+  }]);
+
+  return SearchSelector;
+}(_react.Component);
+
+/**
+ * Default props
+ * @type {Object}
+ */
+
+
+SearchSelector.defaultProps = {
+  optionComponent: function optionComponent(_ref) {
+    var option = _ref.option;
+    return _react2.default.createElement(
+      'div',
+      null,
+      option.label
+    );
+  },
+  selectedIds: [],
+  perPage: 20,
+  threshold: 1
+};
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+SearchSelector.propTypes = {
+  onSelection: _react2.default.PropTypes.func.isRequired,
+  optionComponent: _react2.default.PropTypes.func,
+  selectedIds: _react2.default.PropTypes.array,
+  params: _react2.default.PropTypes.object,
+  perPage: _react2.default.PropTypes.number,
+  threshold: _react2.default.PropTypes.number,
+  url: _react2.default.PropTypes.string.isRequired
+};
+
+exports.default = SearchSelector;

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -188,6 +188,7 @@ var SearchSelector = function (_Component) {
       var _props3 = this.props;
       var onSelection = _props3.onSelection;
       var optionComponent = _props3.optionComponent;
+      var selectedIds = _props3.selectedIds;
       var _state = this.state;
       var loading = _state.loading;
       var results = _state.results;
@@ -200,15 +201,17 @@ var SearchSelector = function (_Component) {
       // Render each option
       var Option = optionComponent;
       var options = results.map(function (option) {
+        var selected = selectedIds.indexOf(option.id) > -1;
         var onClick = function (e) {
           e.preventDefault();
           onSelection(option.id, option);
         }.bind(_this2);
+        var optionButtonClassNames = (0, _classnames2.default)(_searchSelector2.default.optionButton, _defineProperty({}, '' + _searchSelector2.default.optionButtonSelected, selected));
         return _react2.default.createElement(
           'button',
           {
             key: option.id,
-            className: _searchSelector2.default.optionButton,
+            className: optionButtonClassNames,
             onClick: onClick },
           _react2.default.createElement(Option, { option: option })
         );

--- a/lib/components/ui/search-selector/pagination/index.js
+++ b/lib/components/ui/search-selector/pagination/index.js
@@ -1,0 +1,166 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _pagination = require('./pagination.mcss');
+
+var _pagination2 = _interopRequireDefault(_pagination);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Pagination = function (_Component) {
+  _inherits(Pagination, _Component);
+
+  function Pagination(props) {
+    _classCallCheck(this, Pagination);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Pagination).call(this, props));
+
+    // Bindings
+  }
+
+  _createClass(Pagination, [{
+    key: 'nextPage',
+    value: function nextPage() {
+      var _props = this.props;
+      var currentPage = _props.currentPage;
+      var goToPage = _props.goToPage;
+      var totalPages = _props.totalPages;
+
+      if (currentPage < totalPages) {
+        goToPage(currentPage + 1);
+      }
+    }
+  }, {
+    key: 'prevPage',
+    value: function prevPage() {
+      var _props2 = this.props;
+      var currentPage = _props2.currentPage;
+      var goToPage = _props2.goToPage;
+
+      if (currentPage > 1) {
+        goToPage(currentPage - 1);
+      }
+    }
+  }, {
+    key: 'renderJumpSelect',
+    value: function renderJumpSelect(currentPage, totalPages, goToPage) {
+      // Create an array with the number of pages
+      var pages = Array.apply(null, { length: totalPages }).map(Number.call, Number);
+      return _react2.default.createElement(
+        'select',
+        {
+          onChange: function onChange(e) {
+            return goToPage(e.target.value);
+          },
+          value: currentPage },
+        pages.map(function (i) {
+          var page = i + 1;
+          return _react2.default.createElement(
+            'option',
+            { key: page, value: page },
+            page
+          );
+        })
+      );
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
+
+      var _props3 = this.props;
+      var currentPage = _props3.currentPage;
+      var goToPage = _props3.goToPage;
+      var totalPages = _props3.totalPages;
+
+
+      var jumpSelect = this.renderJumpSelect(currentPage, totalPages, goToPage);
+
+      return _react2.default.createElement(
+        'div',
+        { className: _pagination2.default.base },
+        _react2.default.createElement(
+          'div',
+          { className: _pagination2.default.info },
+          'Page ',
+          jumpSelect,
+          ' of ',
+          totalPages
+        ),
+        _react2.default.createElement(
+          'div',
+          { className: _pagination2.default.buttons },
+          _react2.default.createElement(
+            'button',
+            {
+              className: _pagination2.default.prevButton,
+              disabled: currentPage === 1,
+              onClick: function onClick(e) {
+                _this2.prevPage();
+              } },
+            _react2.default.createElement(
+              'span',
+              { className: _pagination2.default.buttonArrow },
+              '←'
+            ),
+            _react2.default.createElement(
+              'span',
+              { className: _pagination2.default.buttonText },
+              ' Prev'
+            )
+          ),
+          _react2.default.createElement(
+            'button',
+            {
+              className: _pagination2.default.nextButton,
+              disabled: currentPage === totalPages,
+              onClick: function onClick(e) {
+                _this2.nextPage();
+              } },
+            _react2.default.createElement(
+              'span',
+              { className: _pagination2.default.buttonText },
+              'Next '
+            ),
+            _react2.default.createElement(
+              'span',
+              { className: _pagination2.default.buttonArrow },
+              '→'
+            )
+          )
+        )
+      );
+    }
+  }]);
+
+  return Pagination;
+}(_react.Component);
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+
+
+Pagination.propTypes = {
+  currentPage: _react2.default.PropTypes.number.isRequired,
+  totalPages: _react2.default.PropTypes.number.isRequired,
+  goToPage: _react2.default.PropTypes.func.isRequired
+};
+
+exports.default = Pagination;

--- a/lib/components/ui/search-selector/pagination/pagination.mcss
+++ b/lib/components/ui/search-selector/pagination/pagination.mcss
@@ -1,0 +1,32 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error from styles;
+
+.base {
+  display: flex;
+  padding: 0.7rem 1rem;
+}
+
+.info {
+  margin-left: 0;
+  margin-right: auto;
+}
+
+.buttons {
+  margin-left: auto;
+  margin-right: 0;
+}
+  .prevButton {
+    margin-right: 1rem;
+  }
+  .prevButton:hover,
+  .nextButton:hover {
+    color: error;
+  }
+
+.buttonText {
+  text-decoration: underline;
+}
+
+.buttonArrow {
+  composes: fallback from styles;
+}

--- a/lib/components/ui/search-selector/search-selector.mcss
+++ b/lib/components/ui/search-selector/search-selector.mcss
@@ -1,5 +1,5 @@
 @value styles: 'formalist-theme/theme/index.mcss';
-@value greyLight from styles;
+@value greyLight, highlight from styles;
 
 .base {
   min-width: 40rem;
@@ -10,16 +10,13 @@
   max-height: 60rem;
   overflow-y: scroll;
   overflow-scroll: touch;
-  padding-top: 0.5rem;
 }
 
 .search {
-  composes: normal sans greyTintBorder from styles;
+  composes: normal sans from styles;
   appearance: none;
-  border-width: 0;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
   box-sizing: border-box;
+  border: none;
   box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
   padding: 0.5em 0.5em 0.7em 0.5em;
   position: relative;
@@ -60,8 +57,11 @@
   }
 
 .pagination {
-  composes: normal sans from styles;
+  composes: normal sans greyTintBorder from styles;
   box-shadow: 0 3px 0 0 rgba(0, 0, 0, 0.05);
+  border-width: 0;
+  border-top-width: 1px;
+  border-top-style: solid;
   position: relative;
   z-index: 1;
 }
@@ -70,16 +70,25 @@
   composes: small sans greyTintBorder whiteBackground from styles;
   border-width: 0;
   border-bottom-width: 1px;
+  border-top-width: 1px;
   border-style: solid;
   cursor: pointer;
   display: block;
   padding: 0.7rem 1rem;
+  margin-bottom: -1px;
   text-align: left;
   width: 100%;
 }
   .optionButton:hover {
     text-decoration: underline;
   }
+
+.optionButtonSelected {
+  composes: highlightLightBackground highlightDarkColor from styles;
+  border-color: color(#7fc2ea tint(40%));
+  position: relative;
+  z-index: 1;
+}
 
 .noResults {
   text-align: center;

--- a/lib/components/ui/search-selector/search-selector.mcss
+++ b/lib/components/ui/search-selector/search-selector.mcss
@@ -1,0 +1,87 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value greyLight from styles;
+
+.base {
+  min-width: 40rem;
+  position: relative;
+}
+
+.list {
+  max-height: 60rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  padding-top: 0.5rem;
+}
+
+.search {
+  composes: normal sans greyTintBorder from styles;
+  appearance: none;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  box-sizing: border-box;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
+  padding: 0.5em 0.5em 0.7em 0.5em;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+  .search:focus {
+    outline: none;
+  }
+
+.spinner {
+  position: absolute;
+  right: 1rem;
+  top: 0.9rem;
+  z-index: 2;
+}
+
+.results {
+  opacity: 1;
+  transition-duration: 100ms;
+  transition-property: opacity;
+}
+
+.resultsLoading {
+  opacity: 0.5;
+  position: relative;
+}
+  .resultsLoading:before {
+    bottom: 0;
+    content: '';
+    left: 0;
+    pointer-events: all;
+    position: absolute;
+    right: 0;
+    top: 0;
+    background-color: transparent;
+    z-index: 100;
+  }
+
+.pagination {
+  composes: normal sans from styles;
+  box-shadow: 0 3px 0 0 rgba(0, 0, 0, 0.05);
+  position: relative;
+  z-index: 1;
+}
+
+.optionButton {
+  composes: small sans greyTintBorder whiteBackground from styles;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-style: solid;
+  cursor: pointer;
+  display: block;
+  padding: 0.7rem 1rem;
+  text-align: left;
+  width: 100%;
+}
+  .optionButton:hover {
+    text-decoration: underline;
+  }
+
+.noResults {
+  text-align: center;
+  padding: 2rem;
+}

--- a/lib/components/ui/search-selector/search.js
+++ b/lib/components/ui/search-selector/search.js
@@ -1,0 +1,110 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = search;
+
+var _superagent = require('superagent');
+
+var _superagent2 = _interopRequireDefault(_superagent);
+
+var _uid = require('uid');
+
+var _uid2 = _interopRequireDefault(_uid);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var reqs = {};
+
+/**
+ * customError
+ * return an object forming a custom error message
+ * @param  {String} name
+ * @param  {Object} error
+ * @return {Object}
+ */
+
+function customError(name, error) {
+  return {
+    error: error,
+    message: error.message,
+    name: name
+  };
+}
+
+/**
+ * responseStatus
+ * take a response and check the response `status` property
+ * if between 200-300 return the response object
+ * else throw a custom error
+ * @param  {Object} res
+ * @return {Object}
+ */
+
+function responseStatus(res) {
+  if (res.status >= 200 && res.status < 300) {
+    return res;
+  } else {
+    var error = new Error(res.statusText);
+    error.response = res;
+    throw customError('responseStatus', error);
+  }
+}
+
+/**
+ * parseJSON
+ * Take a response object and return the parsed res.text
+ * @param  {String} response
+ * @return {Object}
+ */
+
+function parseJSON(res) {
+  return JSON.parse(res.text);
+}
+
+/**
+ * searchRequest
+ * @return  {Promise}
+ */
+
+function searchRequest(url, params, id) {
+  return new Promise(function (resolve, reject) {
+    reqs[id] = _superagent2.default.get(url).query(params).set({
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }).end(function (err, res) {
+      if (err) return reject(customError('searchRequest', err));
+      resolve(res);
+    });
+  });
+}
+
+/**
+ * Abort an existing request
+ * @param  {String} id UID for the request
+ */
+function abortRequest(id) {
+  var req = reqs[id];
+  if (req) {
+    req.abort();
+  }
+}
+
+function search(url) {
+  var params = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+  var id = (0, _uid2.default)(10);
+  return {
+    abort: function abort() {
+      return abortRequest(id);
+    },
+    response: new Promise(function (resolve, reject) {
+      searchRequest(url, params, id).then(responseStatus).then(parseJSON).then(function (res) {
+        resolve(res);
+      }).catch(function (err) {
+        reject(err);
+      });
+    })
+  };
+}

--- a/lib/components/ui/spinner/index.js
+++ b/lib/components/ui/spinner/index.js
@@ -1,0 +1,49 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _spinner = require('./spinner.mcss');
+
+var _spinner2 = _interopRequireDefault(_spinner);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Spinner = function (_Component) {
+  _inherits(Spinner, _Component);
+
+  function Spinner() {
+    _classCallCheck(this, Spinner);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Spinner).apply(this, arguments));
+  }
+
+  _createClass(Spinner, [{
+    key: 'render',
+    value: function render() {
+      var spinnerClassNames = (0, _classnames2.default)(_spinner2.default.spinner, this.props.className);
+      return _react2.default.createElement('div', { className: spinnerClassNames });
+    }
+  }]);
+
+  return Spinner;
+}(_react.Component);
+
+exports.default = Spinner;

--- a/lib/components/ui/spinner/spinner.mcss
+++ b/lib/components/ui/spinner/spinner.mcss
@@ -1,0 +1,20 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value greyLight, highlightDark from styles;
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  animation: spin 700ms infinite linear;
+  border: .25rem solid greyLight;
+  border-radius: 50%;
+  border-top-color: highlightDark;
+  height: 1rem;
+  width: 1rem;
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "formalist-validation": "icelab/formalist-validation",
     "fuzzy": "0.1.1",
     "is-number": "^2.1.0",
+    "lodash.debounce": "4.0.7",
     "lodash.isequal": "^4.2.0",
     "moment": "^2.13.0",
     "number-is-integer": "^1.0.0",

--- a/src/components/fields/index.js
+++ b/src/components/fields/index.js
@@ -7,6 +7,7 @@ import HiddenField from './hidden-field'
 import MultiSelectionField from './multi-selection-field'
 import NumberField from './number-field'
 import RadioButtons from './radio-buttons'
+import SearchSelectionField from './search-selection-field'
 import SelectBox from './select-box'
 import SelectionField from './selection-field'
 import TextField from './text-field'
@@ -42,6 +43,7 @@ function fields (fieldsConfig = {}, globalConfig = {}) {
     multiSelectionField: wrapField(MultiSelectionField, fieldsConfig.multiSelectionField, globalConfig),
     numberField: wrapField(NumberField, fieldsConfig.numberField, globalConfig),
     radioButtons: wrapField(RadioButtons, fieldsConfig.radioButtons, globalConfig),
+    searchSelectionField: wrapField(SearchSelectionField, fieldsConfig.searchSelectionField, globalConfig),
     selectBox: wrapField(SelectBox, fieldsConfig.selectBox, globalConfig),
     selectionField: wrapField(SelectionField, fieldsConfig.selectionField, globalConfig),
     textArea: wrapField(TextArea, fieldsConfig.textArea, globalConfig),

--- a/src/components/fields/index.js
+++ b/src/components/fields/index.js
@@ -8,6 +8,7 @@ import MultiSelectionField from './multi-selection-field'
 import NumberField from './number-field'
 import RadioButtons from './radio-buttons'
 import SearchSelectionField from './search-selection-field'
+import SearchMultiSelectionField from './search-multi-selection-field'
 import SelectBox from './select-box'
 import SelectionField from './selection-field'
 import TextField from './text-field'
@@ -44,6 +45,7 @@ function fields (fieldsConfig = {}, globalConfig = {}) {
     numberField: wrapField(NumberField, fieldsConfig.numberField, globalConfig),
     radioButtons: wrapField(RadioButtons, fieldsConfig.radioButtons, globalConfig),
     searchSelectionField: wrapField(SearchSelectionField, fieldsConfig.searchSelectionField, globalConfig),
+    searchMultiSelectionField: wrapField(SearchMultiSelectionField, fieldsConfig.searchMultiSelectionField, globalConfig),
     selectBox: wrapField(SelectBox, fieldsConfig.selectBox, globalConfig),
     selectionField: wrapField(SelectionField, fieldsConfig.selectionField, globalConfig),
     textArea: wrapField(TextArea, fieldsConfig.textArea, globalConfig),

--- a/src/components/fields/multi-selection-field/index.js
+++ b/src/components/fields/multi-selection-field/index.js
@@ -220,7 +220,7 @@ const SelectionField = React.createClass({
 
   render () {
     const {attributes, config, errors, hint, label, name, value} = this.props
-    const {instanceKey, search, searchFocus} = this.state
+    const {search, searchFocus} = this.state
     const {options, placeholder, selector_label, render_selection_as, render_option_as} = attributes
     const hasErrors = (errors.count() > 0)
 
@@ -330,7 +330,7 @@ const SelectionField = React.createClass({
             (numberOfSelections > 0)
             ? <div id={name} className={styles.selectedItems}>
               <Sortable canRemove onRemove={this.onRemove} onDrop={this.onDrop}>
-                {selections.map((option, index) => <Selection key={`${instanceKey}_${index}_${option.id}`} option={option} />)}
+                {selections.map((option, index) => <Selection key={`${index}_${option.id}`} option={option} />)}
               </Sortable>
             </div>
             : null

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -49,9 +49,13 @@ class SearchMultiSelectionField extends Component {
   constructor (props) {
     super(props)
 
+    // Keep as a property so can always know the "true" set
+    this.cachedSelections = props.selections
+    this.cachedValue = props.value
+
     // Initial state
     this.state = {
-      selections: props.selections,
+      selections: this.cachedSelections,
       selectorFocus: false,
       selectorQuery: null,
     }
@@ -71,15 +75,21 @@ class SearchMultiSelectionField extends Component {
     this.onSelectorQueryChange = this.onSelectorQueryChange.bind(this)
   }
 
+  componentWillReceiveProps (nextProps) {
+    this.cachedValue = nextProps.value
+  }
+
   /**
    * onChange handler
    *
    * @param  {Event} e Change event from a form input/select
    */
-  onChange (values, selections) {
+  onChange (value, selections) {
+    this.cachedValue = value
+    this.cachedSelections = selections
     this.props.actions.edit(
       (val) => {
-        return values
+        return value
       }
     )
     this.setState({
@@ -102,11 +112,9 @@ class SearchMultiSelectionField extends Component {
    * @return {Null}
    */
   onRemove (index) {
-    const {value} = this.props
-    const {selections} = this.state
     this.onChange(
-      value.delete(index),
-      selections.delete(index)
+      this.cachedValue.delete(index),
+      this.cachedSelections.delete(index)
     )
   }
 
@@ -115,8 +123,8 @@ class SearchMultiSelectionField extends Component {
    * @return {Null}
    */
   onDrop (newOrder) {
-    const value = this.props.value.slice()
-    const selections = this.state.selections.slice()
+    const value = this.cachedValue.slice()
+    const selections = this.cachedSelections.slice()
     const updatedValue = newOrder.map((index) => (
       value.get(index)
     ))
@@ -134,17 +142,16 @@ class SearchMultiSelectionField extends Component {
    * @return {Null}
    */
   onSelection (id, selection) {
-    let {value} = this.props
+    let value = this.cachedValue
     value = value || List()
     // Exists already? Remove it
     const index = value.indexOf(id)
     if (index > -1) {
       this.onRemove(index)
     } else {
-      const {selections} = this.state
       this.onChange(
         value.push(id),
-        selections.push(selection)
+        this.cachedSelections.push(selection)
       )
     }
   }

--- a/src/components/fields/search-multi-selection-field/search-multi-selection-field.mcss
+++ b/src/components/fields/search-multi-selection-field/search-multi-selection-field.mcss
@@ -47,6 +47,7 @@
   margin-bottom: -0.4rem;
 }
 
+
 /**
  * Selections
  */
@@ -85,7 +86,7 @@
   }
 
 .optionButton {
-  composes: normal sans greyTintBorder whiteBackground from styles;
+  composes: small sans greyTintBorder whiteBackground from styles;
   border-width: 0;
   border-bottom-width: 1px;
   border-style: solid;
@@ -107,4 +108,3 @@
 .optionButton em {
   font-style: italic;
 }
-

--- a/src/components/fields/search-selection-field/index.js
+++ b/src/components/fields/search-selection-field/index.js
@@ -50,7 +50,9 @@ class SearchSelectionField extends Component {
 
     // Initial state
     this.state = {
-      selection: props.selection
+      selection: props.selection,
+      selectorFocus: false,
+      selectorQuery: null,
     }
 
     // Bindings
@@ -62,6 +64,9 @@ class SearchSelectionField extends Component {
     this.closeSelector = this.closeSelector.bind(this)
     this.toggleSelector = this.toggleSelector.bind(this)
     this.onPopoutOpen = this.onPopoutOpen.bind(this)
+    this.onSelectorBlur = this.onSelectorBlur.bind(this)
+    this.onSelectorFocus = this.onSelectorFocus.bind(this)
+    this.onSelectorQueryChange = this.onSelectorQueryChange.bind(this)
   }
 
   /**
@@ -139,10 +144,38 @@ class SearchSelectionField extends Component {
     this._selector.focusSearch()
   }
 
+  /**
+   * On selector focus
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSelectorFocus (e) {
+    this.setState({
+      selectorFocus: true,
+    })
+  }
+
+  /**
+   * On selector blur
+   * @param  {Event} e Keyboard event
+   * @return {Null}
+   */
+  onSelectorBlur (e) {
+    this.setState({
+      selectorFocus: false,
+    })
+  }
+
+  onSelectorQueryChange (selectorQuery) {
+    this.setState({
+      selectorQuery,
+    })
+  }
+
   render () {
     const {attributes, config, errors, hint, label, name, value} = this.props
     const {placeholder, selector_label, render_option_as, render_selection_as} = attributes
-    const {selection} = this.state
+    const {selection, selectorFocus, selectorQuery} = this.state
     const hasErrors = (errors.count() > 0)
 
     // Set up field classes
@@ -187,16 +220,20 @@ class SearchSelectionField extends Component {
               <div className={styles.selectionPlaceholder}>
                 {placeholder || 'Make a selection'}
               </div>
-              <Popout ref={(r) => this._popout = r} placement='left' closeOnEsc onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnEsc={true} closeOnOutsideClick>
+              <Popout ref={(r) => this._popout = r} placement='left' onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnEsc={!selectorFocus || !selectorQuery} closeOnOutsideClick>
                 <div className={styles.openSelectorButton}>
                   {selector_label || 'Select'}
                 </div>
                 <SearchSelector
                   ref={(r) => this._selector = r}
                   onSelection={this.onSelection}
+                  onBlur={this.onSelectorBlur}
+                  onFocus={this.onSelectorFocus}
+                  onQueryChange={this.onSelectorQueryChange}
                   optionComponent={Option}
                   params={attributes.search_params}
                   perPage={attributes.search_per_page}
+                  query={selectorQuery}
                   threshold={attributes.search_threshold}
                   url={attributes.search_url} />
               </Popout>

--- a/src/components/fields/search-selection-field/index.js
+++ b/src/components/fields/search-selection-field/index.js
@@ -1,0 +1,249 @@
+import React, {Component} from 'react'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+import classNames from 'classnames'
+import fuzzy from 'fuzzy'
+import extractComponent from '../../../utils/extract-component'
+
+// Import components
+import FieldErrors from '../common/errors'
+import FieldHeader from '../common/header'
+import Popout from '../../ui/popout'
+import SearchSelector from '../../ui/search-selector'
+
+// Import styles
+import styles from './search-selection-field.mcss'
+
+/**
+ * Default component for representing a "selected/selection" item
+ * @param  {Object} props Taking the shape of:
+ *
+ * {
+ *   option: { label: 'foo'}
+ *  }
+ *
+ * I.e., expecting the option to have a `label` key with a string value.
+ *
+ * @return {ReactElement}
+ */
+const SelectDefault = ({option}) => (
+  <div>
+    {option.label}
+  </div>
+)
+
+SelectDefault.propTypes = {
+  option: React.PropTypes.shape({
+    label: React.PropTypes.string
+  })
+}
+
+/**
+ * Search Selection field
+ *
+ * Handles the singular select of a
+ *
+ */
+class SearchSelectionField extends Component {
+
+  constructor (props) {
+    super(props)
+
+    // Initial state
+    this.state = {
+      selection: props.selection
+    }
+
+    // Bindings
+    this.onChange = this.onChange.bind(this)
+    this.onChooseClick = this.onChooseClick.bind(this)
+    this.onRemoveClick = this.onRemoveClick.bind(this)
+    this.onSelection = this.onSelection.bind(this)
+    this.openSelector = this.openSelector.bind(this)
+    this.closeSelector = this.closeSelector.bind(this)
+    this.toggleSelector = this.toggleSelector.bind(this)
+    this.onPopoutOpen = this.onPopoutOpen.bind(this)
+  }
+
+  /**
+   * onChange handler
+   *
+   * @param  {Event} e Change event from a form input/select
+   */
+  onChange (value, selection) {
+    this.props.actions.edit(
+      (val) => {
+        return value
+      }
+    )
+    this.setState({
+      selection,
+    })
+  }
+
+  /**
+   * On choose click, open selector
+   * @return {Null}
+   */
+  onChooseClick (e) {
+    e.preventDefault()
+    this.toggleSelector()
+  }
+
+  /**
+   * When selected item is removed
+   * @return {Null}
+   */
+  onRemoveClick (e) {
+    e.preventDefault()
+    this.onChange(null, null)
+  }
+
+  /**
+   * When a selection is made, trigger change and close the selector
+   * @return {Null}
+   */
+  onSelection (id, selection) {
+    this.closeSelector()
+    this.onChange(id, selection)
+  }
+
+  /**
+   * Open the selector popout
+   * @return {Null}
+   */
+  openSelector () {
+    this._popout.openPopout()
+  }
+
+  /**
+   * Close the selector popout
+   * @return {Null}
+   */
+  closeSelector () {
+    this._popout.closePopout()
+  }
+
+  /**
+   * Toggle the selector popout
+   * @return {Null}
+   */
+  toggleSelector () {
+    this._popout.togglePopout()
+  }
+
+  /**
+   * On popout open, focus the search input
+   * @return {Null}
+   */
+  onPopoutOpen () {
+    this._selector.focusSearch()
+  }
+
+  render () {
+    const {attributes, config, errors, hint, label, name, value} = this.props
+    const {placeholder, selector_label, render_option_as, render_selection_as} = attributes
+    const {selection} = this.state
+    const hasErrors = (errors.count() > 0)
+
+    // Set up field classes
+    const fieldClassNames = classNames(
+      styles.base,
+      {
+        [`${styles.baseInline}`]: attributes.inline
+      }
+    )
+
+    // Determine the selection/selected display components
+    let Option = SelectDefault
+    let Selection = SelectDefault
+
+    // Extract them from the passed `config.components` if it exists
+    if (config.components) {
+      if (render_option_as) {
+        Option = extractComponent(config.components, render_option_as) || Option
+      }
+      if (render_selection_as) {
+        Selection = extractComponent(config.components, render_selection_as) || Selection
+      }
+    }
+
+    return (
+      <div className={fieldClassNames}>
+        <div className={styles.header}>
+          <FieldHeader id={name} label={label} hint={hint} error={hasErrors} />
+        </div>
+        <div className={styles.display}>
+          {(selection)
+            ? <div className={styles.wrapper}>
+              <div id={name} className={styles.selection}>
+                <Selection option={selection} />
+              </div>
+              <button className={styles.remove} onClick={this.onRemoveClick}>
+                <span className={styles.removeText}>Remove</span>
+                <div className={styles.removeX}>×</div>
+              </button>
+            </div>
+            : <button className={styles.wrapper} onClick={this.onChooseClick}>
+              <div className={styles.selectionPlaceholder}>
+                {placeholder || 'Make a selection'}
+              </div>
+              <Popout ref={(r) => this._popout = r} placement='left' closeOnEsc onClose={this.onPopoutClose} onOpen={this.onPopoutOpen} closeOnEsc={true} closeOnOutsideClick>
+                <div className={styles.openSelectorButton}>
+                  {selector_label || 'Select'}
+                </div>
+                <SearchSelector
+                  ref={(r) => this._selector = r}
+                  onSelection={this.onSelection}
+                  optionComponent={Option}
+                  params={attributes.search_params}
+                  perPage={attributes.search_per_page}
+                  threshold={attributes.search_threshold}
+                  url={attributes.search_url} />
+              </Popout>
+            </button>
+          }
+          {(hasErrors) ? <FieldErrors errors={errors} /> : null}
+        </div>
+      </div>
+    )
+  }
+}
+
+/**
+ * Enable parent to pass context
+ */
+SearchSelectionField.contextTypes = {
+ globalConfig: React.PropTypes.object
+}
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+SearchSelectionField.propTypes = {
+  actions: React.PropTypes.object,
+  name: React.PropTypes.string,
+  config: React.PropTypes.object,
+  attributes: React.PropTypes.shape({
+    label: React.PropTypes.string,
+    hint: React.PropTypes.string,
+    placeholder: React.PropTypes.string,
+    inline: React.PropTypes.bool,
+    search_url: React.PropTypes.string,
+    search_per_page: React.PropTypes.number,
+    search_params: React.PropTypes.object,
+    search_threshold: React.PropTypes.number,
+    selector_label: React.PropTypes.string,
+    render_option_as: React.PropTypes.string,
+    render_selection_as: React.PropTypes.string
+  }),
+  hint: React.PropTypes.string,
+  label: React.PropTypes.string,
+  errors: ImmutablePropTypes.list,
+  value: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number
+  ])
+}
+
+export default SearchSelectionField

--- a/src/components/fields/search-selection-field/search-selection-field.mcss
+++ b/src/components/fields/search-selection-field/search-selection-field.mcss
@@ -1,0 +1,135 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error, fontSansBoldWeight, highlightLight: from styles;
+
+.base {
+  composes: base from '../shared.mcss';
+}
+  .baseInline {
+    composes: baseInline from '../shared.mcss';
+  }
+
+.display {
+  composes: inputBox from '../../ui/input-boxes.mcss';
+}
+
+/**
+ *
+ */
+
+.wrapper {
+  align-items: center;
+  display: flex;
+  padding: 0;
+  width: 100%;
+}
+  .wrapper:focus {
+    outline: none;
+  }
+
+.selection {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  text-align: left;
+  min-height: 2rem;
+}
+
+.selectionPlaceholder {
+  composes: selection;
+  composes: greyMidColor normal sans from styles;
+}
+
+.openSelectorButton {
+  composes: small buttonHighlight from '../../ui/buttons.mcss';
+  margin-right: -0.3rem;
+  margin-top: -0.2rem;
+  margin-bottom: -0.4rem;
+}
+
+/* Selection exists */
+
+.remove {
+  composes: primaryColor from styles;
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.17em;
+  margin-top: -0.3rem;
+  margin-bottom: -0.3rem;
+  transition-property: color;
+  transition-duration: 100ms;
+}
+  .remove:focus,
+  .remove:hover {
+    color: error;
+  }
+
+.removeText {
+  display: none;
+}
+
+.removeX {
+  composes: fallback large from styles;
+}
+
+/**
+ * Selections
+ */
+
+.options {
+  min-width: 30rem;
+}
+
+.optionsList {
+  max-height: 40rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  padding-top: 0.5rem;
+}
+
+.noResults {
+  composes: normal sans from styles;
+  padding: 0.5em 1rem 0.7em;
+}
+
+.search {
+  composes: normal sans greyTintBorder from styles;
+  appearance: none;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  box-sizing: border-box;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
+  padding: 0.5em 0.5em 0.7em 0.5em;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+  .search:focus {
+    outline: none;
+  }
+
+.optionButton {
+  composes: small sans greyTintBorder whiteBackground from styles;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-style: solid;
+  cursor: pointer;
+  display: block;
+  padding: 0.7rem 1rem;
+  text-align: left;
+  width: 100%;
+}
+  .optionButton:hover {
+    text-decoration: underline;
+  }
+
+.selection strong,
+.optionButton strong {
+  font-weight: fontSansBoldWeight;
+}
+.selection em,
+.optionButton em {
+  font-style: italic;
+}

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -19,7 +19,7 @@ class SearchSelector extends Component {
 
     // Instance vars
     this.page = 1
-    this.query = null
+    this.query = props.query
     // Persistent request object
     this.currentRequest = null
 
@@ -34,14 +34,16 @@ class SearchSelector extends Component {
     this.doSearch = debounce(this.doSearch.bind(this), 250)
     this.onSearchChange = this.onSearchChange.bind(this)
     this.onSearchSuccess = this.onSearchSuccess.bind(this)
+    this.onSearchBlur = this.onSearchBlur.bind(this)
+    this.onSearchFocus = this.onSearchFocus.bind(this)
     this.goToPage = this.goToPage.bind(this)
   }
 
   componentWillMount () {
-    const {threshold} = this.props
+    const {threshold, query} = this.props
     // Do a search for nothing on load if threshold is 0
-    if (threshold === 0) {
-      this.doSearch('')
+    if (query && query.length >= threshold) {
+      this.doSearch(query)
     }
   }
 
@@ -85,11 +87,26 @@ class SearchSelector extends Component {
     }
   }
 
+  onSearchBlur (e) {
+    if (this.props.onBlur) {
+      this.props.onBlur(e)
+    }
+  }
+
+  onSearchFocus (e) {
+    if (this.props.onFocus) {
+      this.props.onFocus(e)
+    }
+  }
+
   onSearchChange (e) {
     const query = e.target.value
     // Reset page value to default
     this.page = 1
     this.doSearch(query)
+    if (this.props.onQueryChange) {
+      this.props.onQueryChange(query)
+    }
   }
 
   onSearchSuccess (rsp) {
@@ -146,7 +163,10 @@ class SearchSelector extends Component {
           ref={(r) => this._search = r}
           type='text'
           className={styles.search}
+          defaultValue={this.query}
           placeholder='Type to search'
+          onBlur={this.onSearchBlur}
+          onFocus={this.onSearchFocus}
           onChange={this.onSearchChange} />
         {
           (loading) ? <Spinner className={styles.spinner}/> : null

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -25,6 +25,7 @@ class SearchSelector extends Component {
 
     // Default state
     this.state = {
+      hasSearched: false,
       loading: false,
       results: [],
       pagination: {},
@@ -77,12 +78,14 @@ class SearchSelector extends Component {
 
       this.setState({
         loading: true,
+        hasSearched: true,
       })
     } else {
       this.setState({
         loading: false,
         results: [],
-        pagination: {}
+        pagination: {},
+        hasSearched: true,
       })
     }
   }
@@ -128,7 +131,7 @@ class SearchSelector extends Component {
 
   render () {
     const {onSelection, optionComponent, selectedIds} = this.props
-    const {loading, results, pagination} = this.state
+    const {hasSearched, loading, results, pagination} = this.state
 
     // Has query?
     const hasQuery = (this.query != null && this.query !== '')
@@ -188,7 +191,7 @@ class SearchSelector extends Component {
                 {options}
               </div>
             </div>
-          : (hasQuery && !loading) ? <p className={styles.noResults}>No results matching your search</p> : null
+          : (hasSearched && hasQuery && !loading) ? <p className={styles.noResults}>No results matching your search</p> : null
         }
       </div>
     )

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -127,7 +127,7 @@ class SearchSelector extends Component {
   }
 
   render () {
-    const {onSelection, optionComponent} = this.props
+    const {onSelection, optionComponent, selectedIds} = this.props
     const {loading, results, pagination} = this.state
 
     // Has query?
@@ -136,14 +136,21 @@ class SearchSelector extends Component {
     // Render each option
     const Option = optionComponent
     const options = results.map((option) => {
+      const selected = (selectedIds.indexOf(option.id) > -1)
       let onClick = function (e) {
         e.preventDefault()
         onSelection(option.id, option)
       }.bind(this)
+      const optionButtonClassNames = classNames(
+        styles.optionButton,
+        {
+          [`${styles.optionButtonSelected}`]: selected,
+        }
+      )
       return (
         <button
           key={option.id}
-          className={styles.optionButton}
+          className={optionButtonClassNames}
           onClick={onClick}>
           <Option option={option} />
         </button>

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -1,0 +1,200 @@
+import React, {Component} from 'react'
+import classNames from 'classnames'
+import debounce from 'lodash.debounce'
+import search from './search'
+import Pagination from './pagination'
+import Spinner from '../spinner'
+
+import styles from './search-selector.mcss'
+
+function abortCurrentSearch (req) {
+  if (req && req.abort) {
+    req.abort()
+  }
+}
+
+class SearchSelector extends Component {
+  constructor (props) {
+    super(props)
+
+    // Instance vars
+    this.page = 1
+    this.query = null
+    // Persistent request object
+    this.currentRequest = null
+
+    // Default state
+    this.state = {
+      loading: false,
+      results: [],
+      pagination: {},
+    }
+
+    // Bindings
+    this.doSearch = debounce(this.doSearch.bind(this), 250)
+    this.onSearchChange = this.onSearchChange.bind(this)
+    this.onSearchSuccess = this.onSearchSuccess.bind(this)
+    this.goToPage = this.goToPage.bind(this)
+  }
+
+  componentWillMount () {
+    const {threshold} = this.props
+    // Do a search for nothing on load if threshold is 0
+    if (threshold === 0) {
+      this.doSearch('')
+    }
+  }
+
+  componentWillUnmount () {
+    abortCurrentSearch(this.currentRequest)
+  }
+
+  doSearch (query) {
+    const {
+      params,
+      perPage,
+      threshold,
+      url,
+    } = this.props
+    this.query = (query != null) ? query : this.query
+    // Abort any existing requests
+    abortCurrentSearch(this.currentRequest)
+
+    // Only search if have enough characters
+    if (this.query.length >= threshold) {
+      // Save the current request
+      const data = Object.assign({}, params, {
+        q: this.query,
+        page: this.page,
+        per_page: perPage,
+      })
+      const req = search(url, data)
+      req.response
+        .then(this.onSearchSuccess)
+      this.currentRequest = req
+
+      this.setState({
+        loading: true,
+      })
+    } else {
+      this.setState({
+        loading: false,
+        results: [],
+        pagination: {}
+      })
+    }
+  }
+
+  onSearchChange (e) {
+    const query = e.target.value
+    // Reset page value to default
+    this.page = 1
+    this.doSearch(query)
+  }
+
+  onSearchSuccess (rsp) {
+    this.setState({
+      loading: false,
+      results: rsp.results,
+      pagination: rsp.pagination,
+    })
+  }
+
+  goToPage (page) {
+    this.page = parseInt(page)
+    this.doSearch()
+  }
+
+  focusSearch () {
+    this._search.focus()
+  }
+
+  render () {
+    const {onSelection, optionComponent} = this.props
+    const {loading, results, pagination} = this.state
+
+    // Has query?
+    const hasQuery = (this.query != null && this.query !== '')
+
+    // Render each option
+    const Option = optionComponent
+    const options = results.map((option) => {
+      let onClick = function (e) {
+        e.preventDefault()
+        onSelection(option.id, option)
+      }.bind(this)
+      return (
+        <button
+          key={option.id}
+          className={styles.optionButton}
+          onClick={onClick}>
+          <Option option={option} />
+        </button>
+      )
+    })
+
+    const resultClassNames = classNames(
+      styles.results,
+      {
+        [`${styles.resultsLoading}`]: loading,
+      }
+    )
+
+    return (
+      <div className={styles.base}>
+        <input
+          ref={(r) => this._search = r}
+          type='text'
+          className={styles.search}
+          placeholder='Type to search'
+          onChange={this.onSearchChange} />
+        {
+          (loading) ? <Spinner className={styles.spinner}/> : null
+        }
+        {
+          (options.length > 0)
+          ? <div className={resultClassNames}>
+              <div className={styles.pagination}>
+                <Pagination currentPage={this.page} totalPages={pagination.total_pages} goToPage={this.goToPage}/>
+              </div>
+              <div className={styles.list}>
+                {options}
+              </div>
+            </div>
+          : (hasQuery && !loading) ? <p className={styles.noResults}>No results matching your search</p> : null
+        }
+      </div>
+    )
+  }
+}
+
+/**
+ * Default props
+ * @type {Object}
+ */
+SearchSelector.defaultProps = {
+  optionComponent: ({option}) => (
+    <div>
+      {option.label}
+    </div>
+  ),
+  selectedIds: [],
+  perPage: 20,
+  threshold: 1,
+}
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+SearchSelector.propTypes = {
+  onSelection: React.PropTypes.func.isRequired,
+  optionComponent: React.PropTypes.func,
+  selectedIds: React.PropTypes.array,
+  params: React.PropTypes.object,
+  perPage: React.PropTypes.number,
+  threshold: React.PropTypes.number,
+  url: React.PropTypes.string.isRequired,
+}
+
+export default SearchSelector

--- a/src/components/ui/search-selector/pagination/index.js
+++ b/src/components/ui/search-selector/pagination/index.js
@@ -1,0 +1,87 @@
+import React, {Component} from 'react'
+import styles from './pagination.mcss'
+
+class Pagination extends Component {
+  constructor (props) {
+    super(props)
+
+    // Bindings
+  }
+
+  nextPage () {
+    const {currentPage, goToPage, totalPages} = this.props
+    if (currentPage < totalPages) {
+      goToPage(currentPage + 1)
+    }
+  }
+
+  prevPage () {
+    const {currentPage, goToPage} = this.props
+    if (currentPage > 1) {
+      goToPage(currentPage - 1)
+    }
+  }
+
+  renderJumpSelect (currentPage, totalPages, goToPage) {
+    // Create an array with the number of pages
+    const pages = Array.apply(null, {length: totalPages}).map(Number.call, Number)
+    return (
+      <select
+        onChange={(e) => goToPage(e.target.value)}
+        value={currentPage}>
+        {
+          pages.map((i) => {
+            const page = i + 1
+            return <option key={page} value={page}>{page}</option>
+          })
+        }
+      </select>
+    )
+  }
+
+  render () {
+    const {currentPage, goToPage, totalPages} = this.props
+
+    const jumpSelect = this.renderJumpSelect(currentPage, totalPages, goToPage)
+
+    return (
+      <div className={styles.base}>
+        <div className={styles.info}>
+          Page {jumpSelect} of {totalPages}
+        </div>
+        <div className={styles.buttons}>
+          <button
+            className={styles.prevButton}
+            disabled={(currentPage === 1)}
+            onClick={(e) => {
+              this.prevPage()
+            }}>
+            <span className={styles.buttonArrow}>←</span>
+            <span className={styles.buttonText}> Prev</span>
+          </button>
+          <button
+            className={styles.nextButton}
+            disabled={(currentPage === totalPages)}
+            onClick={(e) => {
+              this.nextPage()
+            }}>
+            <span className={styles.buttonText}>Next </span>
+            <span className={styles.buttonArrow}>→</span>
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
+
+/**
+ * PropTypes
+ * @type {Object}
+ */
+Pagination.propTypes = {
+  currentPage: React.PropTypes.number.isRequired,
+  totalPages: React.PropTypes.number.isRequired,
+  goToPage: React.PropTypes.func.isRequired,
+}
+
+export default Pagination

--- a/src/components/ui/search-selector/pagination/pagination.mcss
+++ b/src/components/ui/search-selector/pagination/pagination.mcss
@@ -1,0 +1,32 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value error from styles;
+
+.base {
+  display: flex;
+  padding: 0.7rem 1rem;
+}
+
+.info {
+  margin-left: 0;
+  margin-right: auto;
+}
+
+.buttons {
+  margin-left: auto;
+  margin-right: 0;
+}
+  .prevButton {
+    margin-right: 1rem;
+  }
+  .prevButton:hover,
+  .nextButton:hover {
+    color: error;
+  }
+
+.buttonText {
+  text-decoration: underline;
+}
+
+.buttonArrow {
+  composes: fallback from styles;
+}

--- a/src/components/ui/search-selector/search-selector.mcss
+++ b/src/components/ui/search-selector/search-selector.mcss
@@ -1,5 +1,5 @@
 @value styles: 'formalist-theme/theme/index.mcss';
-@value greyLight from styles;
+@value greyLight, highlight from styles;
 
 .base {
   min-width: 40rem;
@@ -10,16 +10,13 @@
   max-height: 60rem;
   overflow-y: scroll;
   overflow-scroll: touch;
-  padding-top: 0.5rem;
 }
 
 .search {
-  composes: normal sans greyTintBorder from styles;
+  composes: normal sans from styles;
   appearance: none;
-  border-width: 0;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
   box-sizing: border-box;
+  border: none;
   box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
   padding: 0.5em 0.5em 0.7em 0.5em;
   position: relative;
@@ -60,8 +57,11 @@
   }
 
 .pagination {
-  composes: normal sans from styles;
+  composes: normal sans greyTintBorder from styles;
   box-shadow: 0 3px 0 0 rgba(0, 0, 0, 0.05);
+  border-width: 0;
+  border-top-width: 1px;
+  border-top-style: solid;
   position: relative;
   z-index: 1;
 }
@@ -70,16 +70,25 @@
   composes: small sans greyTintBorder whiteBackground from styles;
   border-width: 0;
   border-bottom-width: 1px;
+  border-top-width: 1px;
   border-style: solid;
   cursor: pointer;
   display: block;
   padding: 0.7rem 1rem;
+  margin-bottom: -1px;
   text-align: left;
   width: 100%;
 }
   .optionButton:hover {
     text-decoration: underline;
   }
+
+.optionButtonSelected {
+  composes: highlightLightBackground highlightDarkColor from styles;
+  border-color: color(#7fc2ea tint(40%));
+  position: relative;
+  z-index: 1;
+}
 
 .noResults {
   text-align: center;

--- a/src/components/ui/search-selector/search-selector.mcss
+++ b/src/components/ui/search-selector/search-selector.mcss
@@ -1,0 +1,87 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value greyLight from styles;
+
+.base {
+  min-width: 40rem;
+  position: relative;
+}
+
+.list {
+  max-height: 60rem;
+  overflow-y: scroll;
+  overflow-scroll: touch;
+  padding-top: 0.5rem;
+}
+
+.search {
+  composes: normal sans greyTintBorder from styles;
+  appearance: none;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  box-sizing: border-box;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.02);
+  padding: 0.5em 0.5em 0.7em 0.5em;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+  .search:focus {
+    outline: none;
+  }
+
+.spinner {
+  position: absolute;
+  right: 1rem;
+  top: 0.9rem;
+  z-index: 2;
+}
+
+.results {
+  opacity: 1;
+  transition-duration: 100ms;
+  transition-property: opacity;
+}
+
+.resultsLoading {
+  opacity: 0.5;
+  position: relative;
+}
+  .resultsLoading:before {
+    bottom: 0;
+    content: '';
+    left: 0;
+    pointer-events: all;
+    position: absolute;
+    right: 0;
+    top: 0;
+    background-color: transparent;
+    z-index: 100;
+  }
+
+.pagination {
+  composes: normal sans from styles;
+  box-shadow: 0 3px 0 0 rgba(0, 0, 0, 0.05);
+  position: relative;
+  z-index: 1;
+}
+
+.optionButton {
+  composes: small sans greyTintBorder whiteBackground from styles;
+  border-width: 0;
+  border-bottom-width: 1px;
+  border-style: solid;
+  cursor: pointer;
+  display: block;
+  padding: 0.7rem 1rem;
+  text-align: left;
+  width: 100%;
+}
+  .optionButton:hover {
+    text-decoration: underline;
+  }
+
+.noResults {
+  text-align: center;
+  padding: 2rem;
+}

--- a/src/components/ui/search-selector/search.js
+++ b/src/components/ui/search-selector/search.js
@@ -1,0 +1,101 @@
+import request from 'superagent'
+import uid from 'uid'
+
+const reqs = {}
+
+/**
+ * customError
+ * return an object forming a custom error message
+ * @param  {String} name
+ * @param  {Object} error
+ * @return {Object}
+ */
+
+function customError (name, error) {
+  return {
+    error,
+    message: error.message,
+    name
+  }
+}
+
+/**
+ * responseStatus
+ * take a response and check the response `status` property
+ * if between 200-300 return the response object
+ * else throw a custom error
+ * @param  {Object} res
+ * @return {Object}
+ */
+
+function responseStatus (res) {
+  if (res.status >= 200 && res.status < 300) {
+    return res
+  } else {
+    let error = new Error(res.statusText)
+    error.response = res
+    throw customError ('responseStatus', error)
+  }
+}
+
+/**
+ * parseJSON
+ * Take a response object and return the parsed res.text
+ * @param  {String} response
+ * @return {Object}
+ */
+
+function parseJSON (res) {
+  return JSON.parse(res.text)
+}
+
+
+/**
+ * searchRequest
+ * @return  {Promise}
+ */
+
+function searchRequest (url, params, id) {
+  return new Promise((resolve, reject) => {
+    reqs[id] = request
+      .get(url)
+      .query(params)
+      .set({
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      })
+      .end((err, res) => {
+        if (err) return reject(customError('searchRequest', err))
+        resolve(res)
+      })
+  })
+}
+
+/**
+ * Abort an existing request
+ * @param  {String} id UID for the request
+ */
+function abortRequest (id) {
+  const req = reqs[id]
+  if (req) {
+    req.abort()
+  }
+}
+
+export default function search (url, params = {}) {
+  const id = uid(10)
+  return {
+    abort: () => abortRequest(id),
+    response: new Promise((resolve, reject) => {
+      searchRequest(url, params, id)
+        .then(responseStatus)
+        .then(parseJSON)
+        .then((res) => {
+          resolve(res)
+        })
+        .catch((err) => {
+          reject(err)
+        })
+    })
+  }
+}

--- a/src/components/ui/spinner/index.js
+++ b/src/components/ui/spinner/index.js
@@ -1,0 +1,14 @@
+import React, {Component} from 'react'
+import classNames from 'classnames'
+import styles from './spinner.mcss'
+
+class Spinner extends Component {
+  render () {
+    const spinnerClassNames = classNames(styles.spinner, this.props.className)
+    return (
+      <div className={spinnerClassNames}></div>
+    )
+  }
+}
+
+export default Spinner

--- a/src/components/ui/spinner/spinner.mcss
+++ b/src/components/ui/spinner/spinner.mcss
@@ -1,0 +1,20 @@
+@value styles: 'formalist-theme/theme/index.mcss';
+@value greyLight, highlightDark from styles;
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  animation: spin 700ms infinite linear;
+  border: .25rem solid greyLight;
+  border-radius: 50%;
+  border-top-color: highlightDark;
+  height: 1rem;
+  width: 1rem;
+}


### PR DESCRIPTION
Adds two fields:

* `<SearchSelectionField>`
* `<SearchMultiSelectionField>`

These allow us to do search over xhr rather than having to provide all the options to the field up front as with the `<SelectionField>` and `<MultiSelectionField>`. They expect these attributes to be set:

* `search_url` — the endpoint to hit
* `search_per_page` — the `per_page` param to pass through to the search URL
* `search_params` — any additional params to be sent `file_type: :image` —> `&file_type=image`
* `search_threshold` — the threshold to trigger a search. This defaults to `1`, setting to `0` means a search for `''` will be triggered on mount.
* `selections` — the extended data for existing selections (to accompany the general field `value`).

You can also send these attributes:

* `selector_label` — the label for the selector button
* `render_option_as` — the name (string) of a component to render as pass through in the `formalist-standard-react` configuration
* `render_selection_as` — the name (string) of a component to render as pass through in the `formalist-standard-react` configuration

Query values will be passed through as `?q=foobar`, page number as `&page=3` and per page value as `&per_page=30`. These can’t yet be configured.

The component expects the response from the `search_url` to conform to a certain format:

```
{
    "results": [{
        "id": 1,
        "label": "Option 1 for asdf"
    }, {
        "id": 2,
        "label": "Option 2 for asdf"
    }, {
        "id": 3,
        "label": "Option 3 for asdf"
    }, {
        "id": 4,
        "label": "Option 4 for asdf"
    }, {
        "id": 5,
        "label": "Option 5 for asdf"
    }],
    "pagination": {
        "page": 1,
        "per_page": 5,
        "total_pages": 10,
        "total_results": 45
    }
}
```

Note the `pagination` block at the bottom.