### PR TITLE
Handle lack of content properly in `richTextArea` fields

### DIFF
--- a/lib/components/fields/rich-text-area/index.js
+++ b/lib/components/fields/rich-text-area/index.js
@@ -101,6 +101,8 @@ var RichTextArea = _react2.default.createClass({
    * @param  {EditorState} editorState State from the editor
    */
   onChange: function onChange(editorState) {
+    var value = this.props.value;
+
     var exporterOptions = {
       entityModifiers: {
         'formalist': function formalist(data) {
@@ -111,10 +113,19 @@ var RichTextArea = _react2.default.createClass({
         }
       }
     };
-    // Persist the value to the AST
-    this.props.actions.edit(function (val) {
-      return (0, _draftJsAstExporter2.default)(editorState, exporterOptions);
-    });
+    var currentContent = editorState.getCurrentContent();
+    var hasText = currentContent.hasText();
+    var newValue = hasText ? (0, _draftJsAstExporter2.default)(editorState, exporterOptions) : null;
+    var hasChangedToNull = newValue === null && value !== null;
+
+    // Persist the value to the AST, but only if it is:
+    // * Not null
+    // * Has changed to null
+    if (newValue != null || hasChangedToNull) {
+      this.props.actions.edit(function (val) {
+        return newValue;
+      });
+    }
     // Keep track of the state here
     this.setState({
       editorState: editorState

--- a/src/components/fields/rich-text-area/index.js
+++ b/src/components/fields/rich-text-area/index.js
@@ -62,6 +62,7 @@ const RichTextArea = React.createClass({
    * @param  {EditorState} editorState State from the editor
    */
   onChange (editorState) {
+    const {value} = this.props
     const exporterOptions = {
       entityModifiers: {
         'formalist': (data) => {
@@ -72,12 +73,21 @@ const RichTextArea = React.createClass({
         }
       },
     }
-    // Persist the value to the AST
-    this.props.actions.edit(
-      (val) => {
-        return exporter(editorState, exporterOptions)
-      }
-    )
+    const currentContent = editorState.getCurrentContent()
+    const hasText = currentContent.hasText()
+    const newValue = (hasText) ? exporter(editorState, exporterOptions) : null
+    const hasChangedToNull = (newValue === null && value !== null)
+
+    // Persist the value to the AST, but only if it is:
+    // * Not null
+    // * Has changed to null
+    if (newValue != null || hasChangedToNull) {
+      this.props.actions.edit(
+        (val) => {
+          return newValue
+        }
+      )
+    }
     // Keep track of the state here
     this.setState({
       editorState


### PR DESCRIPTION
The issue is that empty content blocks are representable in the draft-js AST we create, so when it appears there’s no content the editor actually has an empty unstyled block. We now check if there’s any text in the editor using `hasText` and only persist the AST data up if there is some text. At the moment this works because every object within draft-js has to have text (even atomic blocks). If that changes we might need to adjust things to do a more intelligent check.

This fixes #82.