### PR TITLE
Allow inline formatter config to be passed through

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,9 @@
         "babel-preset-es2015",
         "babel-preset-react"
       ],
+      "plugins": [
+        "transform-object-rest-spread"
+      ],
       "ignore": [
         "src/**/*.mcss"
       ]

--- a/lib/components/fields/check-box/index.js
+++ b/lib/components/fields/check-box/index.js
@@ -85,13 +85,13 @@ var CheckBox = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/common/header/index.js
+++ b/lib/components/fields/common/header/index.js
@@ -46,10 +46,10 @@ var FieldHeader = _react2.default.createClass({
     return !(0, _shallowEquals2.default)(this.props, nextProps);
   },
   render: function render() {
-    var _props = this.props,
-        id = _props.id,
-        label = _props.label,
-        hint = _props.hint;
+    var _props = this.props;
+    var id = _props.id;
+    var label = _props.label;
+    var hint = _props.hint;
 
     if (!label && !hint) {
       return null;

--- a/lib/components/fields/container.js
+++ b/lib/components/fields/container.js
@@ -32,9 +32,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var deleteField = _formalistCompose.actions.deleteField,
-    editField = _formalistCompose.actions.editField,
-    validateField = _formalistCompose.actions.validateField;
+var deleteField = _formalistCompose.actions.deleteField;
+var editField = _formalistCompose.actions.editField;
+var validateField = _formalistCompose.actions.validateField;
 
 /**
  * Container class for fields.Consolidates common attributes and actions into a
@@ -82,16 +82,16 @@ var FieldContainer = _react2.default.createClass({
     return this.props.hashCode !== nextProps.hashCode;
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        config = _props.config,
-        errors = _props.errors,
-        field = _props.field,
-        name = _props.name,
-        path = _props.path,
-        rules = _props.rules,
-        store = _props.store,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var config = _props.config;
+    var errors = _props.errors;
+    var field = _props.field;
+    var name = _props.name;
+    var path = _props.path;
+    var rules = _props.rules;
+    var store = _props.store;
+    var value = _props.value;
 
     var Field = field;
 
@@ -100,8 +100,8 @@ var FieldContainer = _react2.default.createClass({
 
     // Extract a few things from attributes
     var label = attributes.label || this.props.name.replace(/_/g, ' ');
-    var _attributes = attributes,
-        hint = _attributes.hint;
+    var _attributes = attributes;
+    var hint = _attributes.hint;
 
     // Curry with the form validation schema
 

--- a/lib/components/fields/date-field/index.js
+++ b/lib/components/fields/date-field/index.js
@@ -84,13 +84,13 @@ var DateField = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/date-time-field/index.js
+++ b/lib/components/fields/date-time-field/index.js
@@ -83,13 +83,13 @@ var DateTimeField = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/multi-selection-field/index.js
+++ b/lib/components/fields/multi-selection-field/index.js
@@ -280,22 +280,22 @@ var SelectionField = _react2.default.createClass({
   render: function render() {
     var _this = this;
 
-    var _props = this.props,
-        attributes = _props.attributes,
-        config = _props.config,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
-    var _state = this.state,
-        search = _state.search,
-        searchFocus = _state.searchFocus;
-    var options = attributes.options,
-        placeholder = attributes.placeholder,
-        selector_label = attributes.selector_label,
-        render_selection_as = attributes.render_selection_as,
-        render_option_as = attributes.render_option_as;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var config = _props.config;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
+    var _state = this.state;
+    var search = _state.search;
+    var searchFocus = _state.searchFocus;
+    var options = attributes.options;
+    var placeholder = attributes.placeholder;
+    var selector_label = attributes.selector_label;
+    var render_selection_as = attributes.render_selection_as;
+    var render_option_as = attributes.render_option_as;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -224,10 +224,10 @@ var MultiUploadField = _react2.default.createClass({
   createFileObjects: function createFileObjects(val) {
     // format the object
     function formatObject(file) {
-      var name = file.name,
-          size = file.size,
-          type = file.type,
-          lastModifiedDate = file.lastModifiedDate;
+      var name = file.name;
+      var size = file.size;
+      var type = file.type;
+      var lastModifiedDate = file.lastModifiedDate;
 
       return {
         file: file,
@@ -469,10 +469,10 @@ var MultiUploadField = _react2.default.createClass({
       this.removeFile(0);
     }
 
-    var permitted_file_type_regex = attributes.permitted_file_type_regex,
-        permitted_file_type_message = attributes.permitted_file_type_message,
-        max_file_size = attributes.max_file_size,
-        max_file_size_message = attributes.max_file_size_message;
+    var permitted_file_type_regex = attributes.permitted_file_type_regex;
+    var permitted_file_type_message = attributes.permitted_file_type_message;
+    var max_file_size = attributes.max_file_size;
+    var max_file_size_message = attributes.max_file_size_message;
 
 
     var status = void 0;
@@ -688,8 +688,8 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   renderInvalidFile: function renderInvalidFile(errorObject, index) {
-    var message = errorObject.message,
-        file = errorObject.file;
+    var message = errorObject.message;
+    var file = errorObject.file;
     var name = file.name;
 
 
@@ -810,9 +810,9 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   renderPreviewItem: function renderPreviewItem(fileObject, index) {
-    var progress = fileObject.progress,
-        file = fileObject.file,
-        fileAttributes = fileObject.fileAttributes;
+    var progress = fileObject.progress;
+    var file = fileObject.file;
+    var fileAttributes = fileObject.fileAttributes;
     var file_name = fileAttributes.file_name;
     var preview = file.preview;
 
@@ -883,9 +883,9 @@ var MultiUploadField = _react2.default.createClass({
 
   renderDefaultTemplate: function renderDefaultTemplate(fileObject, index) {
     var fileAttributes = fileObject.fileAttributes;
-    var file_name = fileAttributes.file_name,
-        thumbnail_url = fileAttributes.thumbnail_url,
-        original_url = fileAttributes.original_url;
+    var file_name = fileAttributes.file_name;
+    var thumbnail_url = fileAttributes.thumbnail_url;
+    var original_url = fileAttributes.original_url;
 
     var hasThumbnail = thumbnail_url != null || (0, _utils.hasImageFormatType)(file_name);
     var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, original_url, file_name) : null;
@@ -1004,9 +1004,9 @@ var MultiUploadField = _react2.default.createClass({
     var _this4 = this;
 
     var isSortable = true;
-    var _props = this.props,
-        config = _props.config,
-        attributes = _props.attributes;
+    var _props = this.props;
+    var config = _props.config;
+    var attributes = _props.attributes;
     var render_uploaded_as = attributes.render_uploaded_as;
 
 
@@ -1034,22 +1034,22 @@ var MultiUploadField = _react2.default.createClass({
    */
 
   render: function render() {
-    var _props2 = this.props,
-        attributes = _props2.attributes,
-        hint = _props2.hint,
-        label = _props2.label,
-        name = _props2.name,
-        errors = _props2.errors;
-    var upload_prompt = attributes.upload_prompt,
-        upload_action_label = attributes.upload_action_label;
+    var _props2 = this.props;
+    var attributes = _props2.attributes;
+    var hint = _props2.hint;
+    var label = _props2.label;
+    var name = _props2.name;
+    var errors = _props2.errors;
+    var upload_prompt = attributes.upload_prompt;
+    var upload_action_label = attributes.upload_action_label;
 
 
     var hasErrors = errors.count() > 0;
 
-    var _state = this.state,
-        XHRErrorMessages = _state.XHRErrorMessages,
-        files = _state.files,
-        invalidFiles = _state.invalidFiles;
+    var _state = this.state;
+    var XHRErrorMessages = _state.XHRErrorMessages;
+    var files = _state.files;
+    var invalidFiles = _state.invalidFiles;
 
     // Set up field classes
 

--- a/lib/components/fields/number-field/index.js
+++ b/lib/components/fields/number-field/index.js
@@ -98,13 +98,13 @@ var NumberField = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/radio-buttons/index.js
+++ b/lib/components/fields/radio-buttons/index.js
@@ -102,13 +102,13 @@ var RadioButtons = _react2.default.createClass({
   render: function render() {
     var _this = this;
 
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/rich-text-area/index.js
+++ b/lib/components/fields/rich-text-area/index.js
@@ -131,12 +131,13 @@ var RichTextArea = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var config = _props.config;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
     var editorState = this.state.editorState;
 
     var hasErrors = errors.count() > 0;
@@ -157,6 +158,7 @@ var RichTextArea = _react2.default.createClass({
         { className: _richTextArea2.default.display },
         _react2.default.createElement(_richTextEditor2.default, {
           editorState: editorState,
+          config: config,
           onChange: this.onChange,
           inlineFormatters: attributes.inline_formatters,
           blockFormatters: attributes.block_formatters,

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -303,22 +303,22 @@ var SearchMultiSelectionField = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props = this.props,
-          attributes = _props.attributes,
-          config = _props.config,
-          errors = _props.errors,
-          hint = _props.hint,
-          label = _props.label,
-          name = _props.name,
-          value = _props.value;
-      var placeholder = attributes.placeholder,
-          selector_label = attributes.selector_label,
-          render_option_as = attributes.render_option_as,
-          render_selection_as = attributes.render_selection_as;
-      var _state = this.state,
-          selections = _state.selections,
-          selectorFocus = _state.selectorFocus,
-          selectorQuery = _state.selectorQuery;
+      var _props = this.props;
+      var attributes = _props.attributes;
+      var config = _props.config;
+      var errors = _props.errors;
+      var hint = _props.hint;
+      var label = _props.label;
+      var name = _props.name;
+      var value = _props.value;
+      var placeholder = attributes.placeholder;
+      var selector_label = attributes.selector_label;
+      var render_option_as = attributes.render_option_as;
+      var render_selection_as = attributes.render_selection_as;
+      var _state = this.state;
+      var selections = _state.selections;
+      var selectorFocus = _state.selectorFocus;
+      var selectorQuery = _state.selectorQuery;
 
       var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/search-selection-field/index.js
+++ b/lib/components/fields/search-selection-field/index.js
@@ -259,21 +259,21 @@ var SearchSelectionField = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props = this.props,
-          attributes = _props.attributes,
-          config = _props.config,
-          errors = _props.errors,
-          hint = _props.hint,
-          label = _props.label,
-          name = _props.name;
-      var placeholder = attributes.placeholder,
-          selector_label = attributes.selector_label,
-          render_option_as = attributes.render_option_as,
-          render_selection_as = attributes.render_selection_as;
-      var _state = this.state,
-          selection = _state.selection,
-          selectorFocus = _state.selectorFocus,
-          selectorQuery = _state.selectorQuery;
+      var _props = this.props;
+      var attributes = _props.attributes;
+      var config = _props.config;
+      var errors = _props.errors;
+      var hint = _props.hint;
+      var label = _props.label;
+      var name = _props.name;
+      var placeholder = attributes.placeholder;
+      var selector_label = attributes.selector_label;
+      var render_option_as = attributes.render_option_as;
+      var render_selection_as = attributes.render_selection_as;
+      var _state = this.state;
+      var selection = _state.selection;
+      var selectorFocus = _state.selectorFocus;
+      var selectorQuery = _state.selectorQuery;
 
       var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/select-box/index.js
+++ b/lib/components/fields/select-box/index.js
@@ -85,13 +85,13 @@ var SelectBox = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/selection-field/index.js
+++ b/lib/components/fields/selection-field/index.js
@@ -254,22 +254,22 @@ var SelectionField = _react2.default.createClass({
   render: function render() {
     var _this = this;
 
-    var _props = this.props,
-        attributes = _props.attributes,
-        config = _props.config,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
-    var _state = this.state,
-        search = _state.search,
-        searchFocus = _state.searchFocus;
-    var options = attributes.options,
-        placeholder = attributes.placeholder,
-        selector_label = attributes.selector_label,
-        render_option_as = attributes.render_option_as,
-        render_selection_as = attributes.render_selection_as;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var config = _props.config;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
+    var _state = this.state;
+    var search = _state.search;
+    var searchFocus = _state.searchFocus;
+    var options = attributes.options;
+    var placeholder = attributes.placeholder;
+    var selector_label = attributes.selector_label;
+    var render_option_as = attributes.render_option_as;
+    var render_selection_as = attributes.render_selection_as;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/text-area/index.js
+++ b/lib/components/fields/text-area/index.js
@@ -88,13 +88,13 @@ var TextArea = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
 

--- a/lib/components/fields/text-field/index.js
+++ b/lib/components/fields/text-field/index.js
@@ -86,13 +86,13 @@ var TextField = _react2.default.createClass({
     });
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        errors = _props.errors,
-        hint = _props.hint,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var errors = _props.errors;
+    var hint = _props.hint;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var hasErrors = errors.count() > 0;
     var type = attributes.password ? 'password' : 'text';

--- a/lib/components/group.js
+++ b/lib/components/group.js
@@ -38,9 +38,9 @@ var Group = _react2.default.createClass({
     return this.props.hashCode !== nextProps.hashCode;
   },
   render: function render() {
-    var _props = this.props,
-        attributes = _props.attributes,
-        children = _props.children;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var children = _props.children;
 
     var label = attributes.get('label');
 

--- a/lib/components/many.js
+++ b/lib/components/many.js
@@ -39,10 +39,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-var addManyContent = _formalistCompose.actions.addManyContent,
-    deleteManyContent = _formalistCompose.actions.deleteManyContent,
-    reorderManyContents = _formalistCompose.actions.reorderManyContents,
-    validateMany = _formalistCompose.actions.validateMany;
+var addManyContent = _formalistCompose.actions.addManyContent;
+var deleteManyContent = _formalistCompose.actions.deleteManyContent;
+var reorderManyContents = _formalistCompose.actions.reorderManyContents;
+var validateMany = _formalistCompose.actions.validateMany;
 
 // Components
 
@@ -125,10 +125,10 @@ var Many = _react2.default.createClass({
    */
   addChild: function addChild(e) {
     e.preventDefault();
-    var _props = this.props,
-        attributes = _props.attributes,
-        store = _props.store,
-        path = _props.path;
+    var _props = this.props;
+    var attributes = _props.attributes;
+    var store = _props.store;
+    var path = _props.path;
 
     var validationRules = attributes.get('validation') ? attributes.get('validation').toJS() : null;
 
@@ -143,11 +143,11 @@ var Many = _react2.default.createClass({
    * @return {Null}
    */
   onRemove: function onRemove(index) {
-    var _props2 = this.props,
-        attributes = _props2.attributes,
-        store = _props2.store,
-        contentsPath = _props2.contentsPath,
-        path = _props2.path;
+    var _props2 = this.props;
+    var attributes = _props2.attributes;
+    var store = _props2.store;
+    var contentsPath = _props2.contentsPath;
+    var path = _props2.path;
 
     var childPath = contentsPath.push(index);
     var validationRules = attributes.get('validation') ? attributes.get('validation').toJS() : null;
@@ -162,10 +162,10 @@ var Many = _react2.default.createClass({
    * @return {Null}
    */
   onDrop: function onDrop(newOrder) {
-    var _props3 = this.props,
-        attributes = _props3.attributes,
-        store = _props3.store,
-        path = _props3.path;
+    var _props3 = this.props;
+    var attributes = _props3.attributes;
+    var store = _props3.store;
+    var path = _props3.path;
 
     var validationRules = attributes.get('validation') ? attributes.get('validation').toJS() : null;
 
@@ -173,21 +173,22 @@ var Many = _react2.default.createClass({
     this.updateContentsKey();
   },
   render: function render() {
-    var _props4 = this.props,
-        attributes = _props4.attributes,
-        children = _props4.children,
-        errors = _props4.errors,
-        name = _props4.name;
+    var _props4 = this.props;
+    var attributes = _props4.attributes;
+    var children = _props4.children;
+    var errors = _props4.errors;
+    var name = _props4.name;
 
     var hasErrors = errors.count() > 0;
     var contentsKey = this.state.contentsKey;
 
     // Extract attributes from Immutable.Map
 
-    var _attributes$toJS = attributes.toJS(),
-        label = _attributes$toJS.label,
-        action_label = _attributes$toJS.action_label,
-        placeholder = _attributes$toJS.placeholder;
+    var _attributes$toJS = attributes.toJS();
+
+    var label = _attributes$toJS.label;
+    var action_label = _attributes$toJS.action_label;
+    var placeholder = _attributes$toJS.placeholder;
 
     label = label || name.replace(/_/, ' ');
 

--- a/lib/components/ui/checkbox/index.js
+++ b/lib/components/ui/checkbox/index.js
@@ -78,11 +78,11 @@ var Checkbox = _react2.default.createClass({
   render: function render() {
     var _classNames;
 
-    var _props = this.props,
-        defaultChecked = _props.defaultChecked,
-        label = _props.label,
-        name = _props.name,
-        value = _props.value;
+    var _props = this.props;
+    var defaultChecked = _props.defaultChecked;
+    var label = _props.label;
+    var name = _props.name;
+    var value = _props.value;
 
     var labelClassNames = (0, _classnames2.default)(_checkbox2.default.label, (_classNames = {}, _defineProperty(_classNames, '' + _checkbox2.default.error, this.props.error), _defineProperty(_classNames, '' + _checkbox2.default.focus, this.state.focus), _classNames));
 

--- a/lib/components/ui/date-picker/index.js
+++ b/lib/components/ui/date-picker/index.js
@@ -103,11 +103,11 @@ var DatePicker = _react2.default.createClass({
   render: function render() {
     var _this = this;
 
-    var _props = this.props,
-        id = _props.id,
-        className = _props.className,
-        error = _props.error,
-        placeholder = _props.placeholder;
+    var _props = this.props;
+    var id = _props.id;
+    var className = _props.className;
+    var error = _props.error;
+    var placeholder = _props.placeholder;
     var value = this.state.value;
 
     var selectedDay = (0, _moment2.default)(this.state.value, 'l', true).toDate();

--- a/lib/components/ui/date-time-picker/index.js
+++ b/lib/components/ui/date-time-picker/index.js
@@ -107,10 +107,10 @@ var DateTimePicker = _react2.default.createClass({
     this.props.onChange(this.dateTime.format(dateFormats.utc));
   },
   render: function render() {
-    var _props = this.props,
-        error = _props.error,
-        id = _props.id,
-        placeholder = _props.placeholder;
+    var _props = this.props;
+    var error = _props.error;
+    var id = _props.id;
+    var placeholder = _props.placeholder;
 
 
     var dateValue = this.state.date;

--- a/lib/components/ui/dropzone/index.js
+++ b/lib/components/ui/dropzone/index.js
@@ -229,17 +229,17 @@ exports.default = _react2.default.createClass({
     var _classNames,
         _this = this;
 
-    var _state = this.state,
-        files = _state.files,
-        isActive = _state.isActive;
-    var _props = this.props,
-        buttonText = _props.buttonText,
-        renderPreview = _props.renderPreview,
-        multiple = _props.multiple,
-        children = _props.children,
-        disableClick = _props.disableClick,
-        hideDropZoneBtn = _props.hideDropZoneBtn,
-        label = _props.label;
+    var _state = this.state;
+    var files = _state.files;
+    var isActive = _state.isActive;
+    var _props = this.props;
+    var buttonText = _props.buttonText;
+    var renderPreview = _props.renderPreview;
+    var multiple = _props.multiple;
+    var children = _props.children;
+    var disableClick = _props.disableClick;
+    var hideDropZoneBtn = _props.hideDropZoneBtn;
+    var label = _props.label;
 
 
     var dropZoneClassNames = (0, _classnames2.default)(_index2.default.dropzone, (_classNames = {}, _defineProperty(_classNames, '' + _index2.default.dropzone__empty, !children), _defineProperty(_classNames, '' + _index2.default.dropzone__disable_hover, children), _defineProperty(_classNames, '' + _index2.default.dropzone__drag_over, isActive), _classNames));

--- a/lib/components/ui/file-input/index.js
+++ b/lib/components/ui/file-input/index.js
@@ -88,10 +88,10 @@ exports.default = _react2.default.createClass({
    */
 
   render: function render() {
-    var _props = this.props,
-        name = _props.name,
-        onChange = _props.onChange,
-        className = _props.className;
+    var _props = this.props;
+    var name = _props.name;
+    var onChange = _props.onChange;
+    var className = _props.className;
 
 
     return _react2.default.createElement(

--- a/lib/components/ui/modal/index.js
+++ b/lib/components/ui/modal/index.js
@@ -169,9 +169,9 @@ var Modal = _react2.default.createClass({
     var _this = this;
 
     // Extract Portal props
-    var _props = this.props,
-        beforeClose = _props.beforeClose,
-        onUpdate = _props.onUpdate;
+    var _props = this.props;
+    var beforeClose = _props.beforeClose;
+    var onUpdate = _props.onUpdate;
     var isOpened = this.state.isOpened;
 
 

--- a/lib/components/ui/popout/index.js
+++ b/lib/components/ui/popout/index.js
@@ -282,13 +282,13 @@ var Popout = _react2.default.createClass({
     var _this = this;
 
     // Extract Portal props
-    var _props = this.props,
-        beforeClose = _props.beforeClose,
-        onUpdate = _props.onUpdate;
+    var _props = this.props;
+    var beforeClose = _props.beforeClose;
+    var onUpdate = _props.onUpdate;
     var placement = this.props.placement;
-    var _state = this.state,
-        isOpened = _state.isOpened,
-        position = _state.position;
+    var _state = this.state;
+    var isOpened = _state.isOpened;
+    var position = _state.position;
 
     // Extract the reference element
     // AKA child.first

--- a/lib/components/ui/popunder/index.js
+++ b/lib/components/ui/popunder/index.js
@@ -229,12 +229,12 @@ var Popunder = _react2.default.createClass({
     var _this = this;
 
     // Extract Portal props
-    var _props = this.props,
-        beforeClose = _props.beforeClose,
-        onUpdate = _props.onUpdate;
-    var _state = this.state,
-        isOpened = _state.isOpened,
-        position = _state.position;
+    var _props = this.props;
+    var beforeClose = _props.beforeClose;
+    var onUpdate = _props.onUpdate;
+    var _state = this.state;
+    var isOpened = _state.isOpened;
+    var position = _state.position;
 
     // Extract the reference element
     // AKA child.first

--- a/lib/components/ui/radio-button/index.js
+++ b/lib/components/ui/radio-button/index.js
@@ -76,12 +76,12 @@ var RadioButton = _react2.default.createClass({
     var _classNames,
         _this = this;
 
-    var _props = this.props,
-        defaultChecked = _props.defaultChecked,
-        label = _props.label,
-        name = _props.name,
-        onChange = _props.onChange,
-        value = _props.value;
+    var _props = this.props;
+    var defaultChecked = _props.defaultChecked;
+    var label = _props.label;
+    var name = _props.name;
+    var onChange = _props.onChange;
+    var value = _props.value;
 
     var labelClassNames = (0, _classnames2.default)(_radioButton2.default.label, (_classNames = {}, _defineProperty(_classNames, '' + _radioButton2.default.error, this.props.error), _defineProperty(_classNames, '' + _radioButton2.default.focus, this.state.focus), _classNames));
 

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/index.js
@@ -58,9 +58,9 @@ var BlockItems = _react2.default.createClass({
     };
   },
   toggleBlockType: function toggleBlockType(blockType) {
-    var _props = this.props,
-        editorState = _props.editorState,
-        onChange = _props.onChange;
+    var _props = this.props;
+    var editorState = _props.editorState;
+    var onChange = _props.onChange;
 
     onChange(_draftJs.RichUtils.toggleBlockType(editorState, blockType));
   },

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic.js
@@ -142,9 +142,9 @@ var AtomicBlock = _react2.default.createClass({
     this.setReadOnly(false);
   },
   remove: function remove() {
-    var _props = this.props,
-        block = _props.block,
-        blockProps = _props.blockProps;
+    var _props = this.props;
+    var block = _props.block;
+    var blockProps = _props.blockProps;
 
     this.setReadOnly(false);
     blockProps.remove(block.getKey());
@@ -159,8 +159,10 @@ var AtomicBlock = _react2.default.createClass({
 
     var isSelected = this.state.isSelected;
 
-    var _entity$getData = this.entity.getData(),
-        label = _entity$getData.label;
+    var _entity$getData = this.entity.getData();
+
+    var label = _entity$getData.label;
+
 
     var containerClassNames = (0, _classnames2.default)(_atomic2.default.container, _defineProperty({}, '' + _atomic2.default.containerSelected, isSelected));
 

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/form-items/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/form-items/index.js
@@ -39,10 +39,10 @@ var FormItems = _react2.default.createClass({
     };
   },
   insertAtomicBlock: function insertAtomicBlock(formConfig) {
-    var _props = this.props,
-        editorState = _props.editorState,
-        onChange = _props.onChange,
-        closeToolbar = _props.closeToolbar;
+    var _props = this.props;
+    var editorState = _props.editorState;
+    var onChange = _props.onChange;
+    var closeToolbar = _props.closeToolbar;
 
     var entityKey = _draftJs.Entity.create('formalist', 'IMMUTABLE', {
       name: formConfig.name,

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -76,13 +76,13 @@ function blockToolbarPlugin() {
 
   // Pull out the options
   options = (0, _mergeDefaults2.default)({}, defaults, options);
-  var _options = options,
-      blockFormatters = _options.blockFormatters,
-      blockRenderMap = _options.blockRenderMap,
-      blockSet = _options.blockSet,
-      editorEmitter = _options.editorEmitter,
-      embeddableForms = _options.embeddableForms,
-      setReadOnly = _options.setReadOnly;
+  var _options = options;
+  var blockFormatters = _options.blockFormatters;
+  var blockRenderMap = _options.blockRenderMap;
+  var blockSet = _options.blockSet;
+  var editorEmitter = _options.editorEmitter;
+  var embeddableForms = _options.embeddableForms;
+  var setReadOnly = _options.setReadOnly;
 
   // Filter out the un-allowed block-item types
 
@@ -113,8 +113,8 @@ function blockToolbarPlugin() {
      * @return {Object} A compatible renderer object definition
      */
     blockRendererFn: function blockRendererFn(contentBlock, _ref) {
-      var getEditorState = _ref.getEditorState,
-          setEditorState = _ref.setEditorState;
+      var getEditorState = _ref.getEditorState;
+      var setEditorState = _ref.setEditorState;
 
       var type = contentBlock.getType();
       // Pull out the renderer from our `blockSet` object
@@ -141,8 +141,8 @@ function blockToolbarPlugin() {
      * @return {Command} String command based on the keyboard event
      */
     keyBindingFn: function keyBindingFn(e, _ref2) {
-      var getEditorState = _ref2.getEditorState,
-          setEditorState = _ref2.setEditorState;
+      var getEditorState = _ref2.getEditorState;
+      var setEditorState = _ref2.setEditorState;
 
       if (selectedAtomicBlockKey !== null) {
         // 46 = DELETE, 8 = BACKSPACE
@@ -173,8 +173,8 @@ function blockToolbarPlugin() {
      * Handle return when atomic blocks are selected
      */
     handleReturn: function handleReturn(e, _ref3) {
-      var getEditorState = _ref3.getEditorState,
-          setEditorState = _ref3.setEditorState;
+      var getEditorState = _ref3.getEditorState;
+      var setEditorState = _ref3.setEditorState;
 
       if (selectedAtomicBlockKey !== null) {
         // Move the selection to the block below so that the content pla
@@ -204,8 +204,8 @@ function blockToolbarPlugin() {
      * @return {Boolean} Did we handle it?
      */
     handleKeyCommand: function handleKeyCommand(command, _ref4) {
-      var getEditorState = _ref4.getEditorState,
-          setEditorState = _ref4.setEditorState;
+      var getEditorState = _ref4.getEditorState;
+      var setEditorState = _ref4.setEditorState;
 
       // Handle deletion of atomic blocks using our custom commands
       if (command === commands.DELETE_BLOCK) {

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/toolbar.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/toolbar.js
@@ -110,14 +110,14 @@ var BlockToolbar = _react2.default.createClass({
   render: function render() {
     var _this2 = this;
 
-    var _props = this.props,
-        blockItemsGroups = _props.blockItemsGroups,
-        editorState = _props.editorState,
-        embeddableForms = _props.embeddableForms,
-        onChange = _props.onChange;
-    var _state = this.state,
-        open = _state.open,
-        positionStyle = _state.positionStyle;
+    var _props = this.props;
+    var blockItemsGroups = _props.blockItemsGroups;
+    var editorState = _props.editorState;
+    var embeddableForms = _props.embeddableForms;
+    var onChange = _props.onChange;
+    var _state = this.state;
+    var open = _state.open;
+    var positionStyle = _state.positionStyle;
 
     var currentBlockType = _draftJs.RichUtils.getCurrentBlockType(editorState);
 

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -4,6 +4,12 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+// Plugins
+
+// Styles
+
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -51,10 +57,6 @@ require('./tmp.css');
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-// Plugins
-
-// Styles
-
 
 /**
  * Rich Text Editor
@@ -66,6 +68,7 @@ var RichTextEditor = _react2.default.createClass({
     embeddableForms: _react2.default.PropTypes.object,
     blockFormatters: _react2.default.PropTypes.array,
     boxSize: _react2.default.PropTypes.string,
+    config: _react2.default.PropTypes.object,
     inlineFormatters: _react2.default.PropTypes.array,
     editorState: _react2.default.PropTypes.object.isRequired,
     onChange: _react2.default.PropTypes.func.isRequired,
@@ -112,26 +115,33 @@ var RichTextEditor = _react2.default.createClass({
    * @return {Array} List of draft-js-plugins compatible plugins
    */
   configurePlugins: function configurePlugins() {
-    var _props = this.props,
-        embeddableForms = _props.embeddableForms,
-        blockFormatters = _props.blockFormatters,
-        boxSize = _props.boxSize,
-        inlineFormatters = _props.inlineFormatters;
+    var _props = this.props;
+    var blockFormatters = _props.blockFormatters;
+    var boxSize = _props.boxSize;
+    var config = _props.config;
+    var embeddableForms = _props.embeddableForms;
+    var inlineFormatters = _props.inlineFormatters;
+
+    // Extract config for each type of toolbar
+
+    var block = config.block;
+    var inline = config.inline;
+
 
     var autoListPlugin = (0, _draftJsAutolistPlugin2.default)();
     var singleLinePlugin = (0, _draftJsSingleLinePlugin2.default)();
 
     // Configure the blockToolbarPlugin
     // Pass through any
-    this.blockToolbarPlugin = (0, _blockToolbarPlugin2.default)({
+    this.blockToolbarPlugin = (0, _blockToolbarPlugin2.default)(_extends({
       setReadOnly: this.setReadOnly,
       editorEmitter: this.emitter,
       blockFormatters: blockFormatters,
       embeddableForms: embeddableForms
-    });
-    var inlineToolbarPlugin = (0, _inlineToolbarPlugin2.default)({
-      inlineFormatters: inlineFormatters
-    });
+    }, block));
+    var inlineToolbarPlugin = (0, _inlineToolbarPlugin2.default)(_extends({
+      allowedFormatters: inlineFormatters
+    }, inline));
     // Build up the list of plugins
     var plugins = [inlineToolbarPlugin, (0, _draftJsBlockBreakoutPlugin2.default)()];
     // Add singleLine plugin if the boxSize matches
@@ -196,16 +206,16 @@ var RichTextEditor = _react2.default.createClass({
   render: function render() {
     var _this2 = this;
 
-    var _props2 = this.props,
-        boxSize = _props2.boxSize,
-        blockFormatters = _props2.blockFormatters,
-        editorState = _props2.editorState,
-        placeholder = _props2.placeholder;
-    var _state = this.state,
-        hasFocus = _state.hasFocus,
-        readOnly = _state.readOnly;
-    var BlockToolbar = this.BlockToolbar,
-        InlineToolbar = this.InlineToolbar;
+    var _props2 = this.props;
+    var boxSize = _props2.boxSize;
+    var blockFormatters = _props2.blockFormatters;
+    var editorState = _props2.editorState;
+    var placeholder = _props2.placeholder;
+    var _state = this.state;
+    var hasFocus = _state.hasFocus;
+    var readOnly = _state.readOnly;
+    var BlockToolbar = this.BlockToolbar;
+    var InlineToolbar = this.InlineToolbar;
 
 
     var placeholderBlockType = false;

--- a/lib/components/ui/rich-text-editor/inline-toolbar-plugin/entities/link.js
+++ b/lib/components/ui/rich-text-editor/inline-toolbar-plugin/entities/link.js
@@ -56,8 +56,9 @@ var Link = function (_Component) {
   _createClass(Link, [{
     key: 'render',
     value: function render() {
-      var _Entity$get$getData = _draftJs.Entity.get(this.props.entityKey).getData(),
-          url = _Entity$get$getData.url;
+      var _Entity$get$getData = _draftJs.Entity.get(this.props.entityKey).getData();
+
+      var url = _Entity$get$getData.url;
 
       return _react2.default.createElement(
         'a',
@@ -196,12 +197,12 @@ var ActionHandler = function (_Component2) {
     value: function render() {
       var _this3 = this;
 
-      var _props = this.props,
-          entityKey = _props.entityKey,
-          remove = _props.remove;
-      var _state = this.state,
-          editing = _state.editing,
-          id = _state.id;
+      var _props = this.props;
+      var entityKey = _props.entityKey;
+      var remove = _props.remove;
+      var _state = this.state;
+      var editing = _state.editing;
+      var id = _state.id;
 
       var entity = _draftJs.Entity.get(entityKey);
       var entityData = entity.getData();

--- a/lib/components/ui/rich-text-editor/inline-toolbar-plugin/index.js
+++ b/lib/components/ui/rich-text-editor/inline-toolbar-plugin/index.js
@@ -70,14 +70,23 @@ var entitiesMapping = [{
 
 var defaults = {
   allowedFormatters: ['bold', 'italic', 'code'],
-  allowedEntities: ['link']
+  allowedEntities: ['link'],
+  customStyleMap: {
+    CODE: {
+      fontFamily: 'inconsolata, monospace',
+      lineHeight: 1.35,
+      wordWrap: 'break-word'
+    }
+  },
+  additionalFormatters: [],
+  additionalEntities: []
 };
 
 /**
  * Plugin for the inline toolbar
 
- * @param  {Array} options.inlineFormatters Optional list of inline commands to
- * allow. Will default to defaults.allowedInlineFormatters
+ * @param  {Array} options.allowedFormatters Optional list of inline commands to
+ * allow. Will default to defaults.allowedFormatters
  *
  * @return {Object} draft-js-editor-plugin compatible object
  */
@@ -85,16 +94,36 @@ function inlineToolbarPlugin() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   // Pull out the options
-  options = (0, _mergeDefaults2.default)({}, defaults, options);
-  var _options = options,
-      allowedFormatters = _options.allowedFormatters,
-      allowedEntities = _options.allowedEntities;
+  options = (0, _mergeDefaults2.default)({}, options, defaults);
+  var _options = options;
+  var allowedFormatters = _options.allowedFormatters;
+  var allowedEntities = _options.allowedEntities;
+  var additionalFormatters = _options.additionalFormatters;
+  var additionalEntities = _options.additionalEntities;
+  var customStyleMap = _options.customStyleMap;
 
-  var formatters = formattersMapping.filter(function (item) {
+  // FIXME
+  // At the moment this means we override _all_ allowed formatters options here
+  // to pass through the additional ones. We really need to reconcile the two
+  // lists more effectively
+
+  allowedFormatters = allowedFormatters.concat(additionalFormatters.map(function (formatter) {
+    return formatter.command;
+  }));
+
+  // Reconcile the lists of formatters and entities from various sources
+  var formatters = formattersMapping.concat(additionalFormatters).filter(function (item) {
     return allowedFormatters.indexOf(item.command) > -1;
   });
-  var entities = entitiesMapping.filter(function (entity) {
+  var entities = entitiesMapping.concat(additionalEntities).filter(function (entity) {
     return allowedEntities.indexOf(entity.type.toLowerCase()) > -1;
+  });
+
+  // Update the customStyleMap
+  additionalFormatters.forEach(function (formatter) {
+    if (formatter.styleMap) {
+      customStyleMap[formatter.style] = formatter.styleMap;
+    }
   });
 
   // Collate the decorators from the inlineEntitiesMaping
@@ -119,8 +148,8 @@ function inlineToolbarPlugin() {
      * @return {Boolean} Handled or not?
      */
     handleKeyCommand: function handleKeyCommand(command, _ref) {
-      var getEditorState = _ref.getEditorState,
-          setEditorState = _ref.setEditorState;
+      var getEditorState = _ref.getEditorState;
+      var setEditorState = _ref.setEditorState;
 
       var formatter = formatters.find(function (item) {
         return item.command === command;
@@ -138,13 +167,7 @@ function inlineToolbarPlugin() {
      * https://github.com/facebook/draft-js/pull/354 is merged.
      * @type {Object}
      */
-    customStyleMap: {
-      CODE: {
-        fontFamily: 'inconsolata, monospace',
-        lineHeight: 1.35,
-        wordWrap: 'break-word'
-      }
-    },
+    customStyleMap: customStyleMap,
 
     /**
      * Export the `InlineToolbar` component with curried `options`

--- a/lib/components/ui/rich-text-editor/inline-toolbar-plugin/items/index.js
+++ b/lib/components/ui/rich-text-editor/inline-toolbar-plugin/items/index.js
@@ -51,18 +51,18 @@ var InlineToolbarItems = function (_Component) {
   _createClass(InlineToolbarItems, [{
     key: 'toggleFormat',
     value: function toggleFormat(style) {
-      var _props = this.props,
-          editorState = _props.editorState,
-          onChange = _props.onChange;
+      var _props = this.props;
+      var editorState = _props.editorState;
+      var onChange = _props.onChange;
 
       onChange(_draftJs.RichUtils.toggleInlineStyle(editorState, style));
     }
   }, {
     key: 'toggleEntity',
     value: function toggleEntity(entity, active) {
-      var _props2 = this.props,
-          editorState = _props2.editorState,
-          onChange = _props2.onChange;
+      var _props2 = this.props;
+      var editorState = _props2.editorState;
+      var onChange = _props2.onChange;
 
       if (active) {
         var selection = editorState.getSelection();
@@ -136,9 +136,9 @@ var InlineToolbarItems = function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props3 = this.props,
-          formatters = _props3.formatters,
-          entities = _props3.entities;
+      var _props3 = this.props;
+      var formatters = _props3.formatters;
+      var entities = _props3.entities;
 
       return _react2.default.createElement(
         'div',

--- a/lib/components/ui/rich-text-editor/inline-toolbar-plugin/toolbar.js
+++ b/lib/components/ui/rich-text-editor/inline-toolbar-plugin/toolbar.js
@@ -61,8 +61,8 @@ var Toolbar = _react2.default.createClass({
   componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
     var _this = this;
 
-    var editorState = nextProps.editorState,
-        editorHasFocus = nextProps.editorHasFocus;
+    var editorState = nextProps.editorState;
+    var editorHasFocus = nextProps.editorHasFocus;
     var forceVisible = this.state.forceVisible;
 
     var selection = editorState.getSelection();
@@ -89,9 +89,9 @@ var Toolbar = _react2.default.createClass({
     });
   },
   removeEntity: function removeEntity(entityKey) {
-    var _props = this.props,
-        editorState = _props.editorState,
-        onChange = _props.onChange;
+    var _props = this.props;
+    var editorState = _props.editorState;
+    var onChange = _props.onChange;
 
     var selection = editorState.getSelection();
     onChange(_draftJs.RichUtils.toggleLink(editorState, selection, null));
@@ -132,15 +132,15 @@ var Toolbar = _react2.default.createClass({
   render: function render() {
     var _this2 = this;
 
-    var _props2 = this.props,
-        editorState = _props2.editorState,
-        formatters = _props2.formatters,
-        entities = _props2.entities,
-        onChange = _props2.onChange;
-    var _state = this.state,
-        visible = _state.visible,
-        forceVisible = _state.forceVisible,
-        positionStyle = _state.positionStyle;
+    var _props2 = this.props;
+    var editorState = _props2.editorState;
+    var formatters = _props2.formatters;
+    var entities = _props2.entities;
+    var onChange = _props2.onChange;
+    var _state = this.state;
+    var visible = _state.visible;
+    var forceVisible = _state.forceVisible;
+    var positionStyle = _state.positionStyle;
 
     var SelectedEntityHandler = null;
     var selectedEntity = void 0;
@@ -155,8 +155,9 @@ var Toolbar = _react2.default.createClass({
 
         var _entities$find = entities.find(function (entity) {
           return entity.type.toLowerCase() === selectedEntityType.toLowerCase();
-        }),
-            handler = _entities$find.handler;
+        });
+
+        var handler = _entities$find.handler;
 
         SelectedEntityHandler = handler;
       })();

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -85,9 +85,9 @@ var SearchSelector = function (_Component) {
   _createClass(SearchSelector, [{
     key: 'componentWillMount',
     value: function componentWillMount() {
-      var _props = this.props,
-          threshold = _props.threshold,
-          query = _props.query;
+      var _props = this.props;
+      var threshold = _props.threshold;
+      var query = _props.query;
       // Do a search for nothing on load if threshold is 0
 
       if (query && query.length >= threshold) {
@@ -102,11 +102,11 @@ var SearchSelector = function (_Component) {
   }, {
     key: 'doSearch',
     value: function doSearch(query) {
-      var _props2 = this.props,
-          params = _props2.params,
-          perPage = _props2.perPage,
-          threshold = _props2.threshold,
-          url = _props2.url;
+      var _props2 = this.props;
+      var params = _props2.params;
+      var perPage = _props2.perPage;
+      var threshold = _props2.threshold;
+      var url = _props2.url;
 
       this.query = query != null ? query : this.query;
       // Abort any existing requests
@@ -187,15 +187,15 @@ var SearchSelector = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props3 = this.props,
-          onSelection = _props3.onSelection,
-          optionComponent = _props3.optionComponent,
-          selectedIds = _props3.selectedIds;
-      var _state = this.state,
-          hasSearched = _state.hasSearched,
-          loading = _state.loading,
-          results = _state.results,
-          pagination = _state.pagination;
+      var _props3 = this.props;
+      var onSelection = _props3.onSelection;
+      var optionComponent = _props3.optionComponent;
+      var selectedIds = _props3.selectedIds;
+      var _state = this.state;
+      var hasSearched = _state.hasSearched;
+      var loading = _state.loading;
+      var results = _state.results;
+      var pagination = _state.pagination;
 
       // Has query?
 

--- a/lib/components/ui/search-selector/pagination/index.js
+++ b/lib/components/ui/search-selector/pagination/index.js
@@ -34,10 +34,10 @@ var Pagination = function (_Component) {
   _createClass(Pagination, [{
     key: 'nextPage',
     value: function nextPage() {
-      var _props = this.props,
-          currentPage = _props.currentPage,
-          goToPage = _props.goToPage,
-          totalPages = _props.totalPages;
+      var _props = this.props;
+      var currentPage = _props.currentPage;
+      var goToPage = _props.goToPage;
+      var totalPages = _props.totalPages;
 
       if (currentPage < totalPages) {
         goToPage(currentPage + 1);
@@ -46,9 +46,9 @@ var Pagination = function (_Component) {
   }, {
     key: 'prevPage',
     value: function prevPage() {
-      var _props2 = this.props,
-          currentPage = _props2.currentPage,
-          goToPage = _props2.goToPage;
+      var _props2 = this.props;
+      var currentPage = _props2.currentPage;
+      var goToPage = _props2.goToPage;
 
       if (currentPage > 1) {
         goToPage(currentPage - 1);
@@ -84,10 +84,10 @@ var Pagination = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var _props3 = this.props,
-          currentPage = _props3.currentPage,
-          goToPage = _props3.goToPage,
-          totalPages = _props3.totalPages;
+      var _props3 = this.props;
+      var currentPage = _props3.currentPage;
+      var goToPage = _props3.goToPage;
+      var totalPages = _props3.totalPages;
 
 
       var jumpSelect = this.renderJumpSelect(currentPage, totalPages, goToPage);

--- a/lib/components/ui/select/index.js
+++ b/lib/components/ui/select/index.js
@@ -81,14 +81,14 @@ var Select = _react2.default.createClass({
   render: function render() {
     var _classNames, _classNames2;
 
-    var _props = this.props,
-        children = _props.children,
-        className = _props.className,
-        clearable = _props.clearable,
-        defaultValue = _props.defaultValue,
-        error = _props.error,
-        placeholder = _props.placeholder,
-        size = _props.size;
+    var _props = this.props;
+    var children = _props.children;
+    var className = _props.className;
+    var clearable = _props.clearable;
+    var defaultValue = _props.defaultValue;
+    var error = _props.error;
+    var placeholder = _props.placeholder;
+    var size = _props.size;
     var focus = this.state.focus;
 
 

--- a/lib/components/ui/sortable/index.js
+++ b/lib/components/ui/sortable/index.js
@@ -150,14 +150,14 @@ var Sortable = _react2.default.createClass({
   render: function render() {
     var _this = this;
 
-    var _state = this.state,
-        instanceKey = _state.instanceKey,
-        items = _state.items;
-    var _props = this.props,
-        canRemove = _props.canRemove,
-        onRemove = _props.onRemove,
-        verticalControls = _props.verticalControls,
-        canSort = _props.canSort;
+    var _state = this.state;
+    var instanceKey = _state.instanceKey;
+    var items = _state.items;
+    var _props = this.props;
+    var canRemove = _props.canRemove;
+    var onRemove = _props.onRemove;
+    var verticalControls = _props.verticalControls;
+    var canSort = _props.canSort;
 
     var isSortable = !(canSort === false || items.length <= 1);
 

--- a/lib/components/ui/sortable/item.js
+++ b/lib/components/ui/sortable/item.js
@@ -167,9 +167,9 @@ var Item = _react2.default.createClass({
    */
   onRemoveClick: function onRemoveClick(e) {
     e.preventDefault();
-    var _props = this.props,
-        canRemove = _props.canRemove,
-        onRemove = _props.onRemove;
+    var _props = this.props;
+    var canRemove = _props.canRemove;
+    var onRemove = _props.onRemove;
 
     if (canRemove && onRemove) {
       onRemove(this.props.index, e);
@@ -185,15 +185,15 @@ var Item = _react2.default.createClass({
     e.preventDefault();
   },
   render: function render() {
-    var _props2 = this.props,
-        canSort = _props2.canSort,
-        canRemove = _props2.canRemove,
-        children = _props2.children,
-        connectDragPreview = _props2.connectDragPreview,
-        connectDragSource = _props2.connectDragSource,
-        connectDropTarget = _props2.connectDropTarget,
-        isDragging = _props2.isDragging,
-        verticalControls = _props2.verticalControls;
+    var _props2 = this.props;
+    var canSort = _props2.canSort;
+    var canRemove = _props2.canRemove;
+    var children = _props2.children;
+    var connectDragPreview = _props2.connectDragPreview;
+    var connectDragSource = _props2.connectDragSource;
+    var connectDropTarget = _props2.connectDropTarget;
+    var isDragging = _props2.isDragging;
+    var verticalControls = _props2.verticalControls;
 
     var inline = {
       opacity: isDragging ? 0 : 1

--- a/lib/components/ui/time-picker/index.js
+++ b/lib/components/ui/time-picker/index.js
@@ -163,9 +163,9 @@ var TimePicker = _react2.default.createClass({
   render: function render() {
     var _this2 = this;
 
-    var _props = this.props,
-        error = _props.error,
-        placeholder = _props.placeholder;
+    var _props = this.props;
+    var error = _props.error;
+    var placeholder = _props.placeholder;
     var inputValue = this.state.inputValue;
 
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-cli": "^6.9.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-css-modules-transform": "0.1.1",
+    "babel-plugin-transform-object-rest-spread": "6.16.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "blue-tape": "^0.2.0",

--- a/src/components/fields/rich-text-area/index.js
+++ b/src/components/fields/rich-text-area/index.js
@@ -95,7 +95,7 @@ const RichTextArea = React.createClass({
   },
 
   render () {
-    const {attributes, errors, hint, label, name} = this.props
+    const {attributes, config, errors, hint, label, name} = this.props
     const {editorState} = this.state
     let hasErrors = (errors.count() > 0)
 
@@ -115,6 +115,7 @@ const RichTextArea = React.createClass({
         <div className={styles.display}>
           <RichTextEditor
             editorState={editorState}
+            config={config}
             onChange={this.onChange}
             inlineFormatters={attributes.inline_formatters}
             blockFormatters={attributes.block_formatters}

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -21,6 +21,7 @@ const RichTextEditor = React.createClass({
     embeddableForms: React.PropTypes.object,
     blockFormatters: React.PropTypes.array,
     boxSize: React.PropTypes.string,
+    config: React.PropTypes.object,
     inlineFormatters: React.PropTypes.array,
     editorState: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func.isRequired,
@@ -66,11 +67,16 @@ const RichTextEditor = React.createClass({
    */
   configurePlugins () {
     const {
-      embeddableForms,
       blockFormatters,
       boxSize,
+      config,
+      embeddableForms,
       inlineFormatters,
     } = this.props
+
+    // Extract config for each type of toolbar
+    const {block, inline} = config
+
     const autoListPlugin = createAutoListPlugin()
     const singleLinePlugin = createSingleLinePlugin()
 
@@ -81,9 +87,11 @@ const RichTextEditor = React.createClass({
       editorEmitter: this.emitter,
       blockFormatters,
       embeddableForms,
+      ...block,
     })
     const inlineToolbarPlugin = createInlineToolbarPlugin({
-      inlineFormatters,
+      allowedFormatters: inlineFormatters,
+      ...inline,
     })
     // Build up the list of plugins
     let plugins = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,6 +383,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.13.0.tgz#e741ff3992c578310be45c571bcd90a2f9c5586e"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-transform-cjs-system-require@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-cjs-system-require/-/babel-plugin-transform-cjs-system-require-0.1.1.tgz#ffef26d31bc270e82bdbbd437db2777e85162a29"
@@ -575,6 +579,13 @@ babel-plugin-transform-global-system-wrapper@0.0.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-global-system-wrapper/-/babel-plugin-transform-global-system-wrapper-0.0.1.tgz#afb469cec0e04689b9fe7e8b1fd280fc94a6d8f2"
   dependencies:
     babel-template "^6.9.0"
+
+babel-plugin-transform-object-rest-spread@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz#db441d56fffc1999052fdebe2e2f25ebd28e36a9"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.0.0"
 
 babel-plugin-transform-react-display-name@^6.3.13:
   version "6.8.0"


### PR DESCRIPTION
```js
const formConfig = {
  fields: {
    richTextArea: {
      inline: {
        additionalFormatters: [{
          command: 'dropcap',
          label: 'Dropcap',
          style: 'DROPCAP',
          styleMap: {
            'fontWeight': 'bold',
            'fontSize': '3em',
            'lineHeight': '0.99',
            'paddingRight': '0.1em',
          },
          icon: ‘svg_goes_here’,
        }],
      },
    },
  }
}

let configuredTemplate = template({}, formConfig)
```