### PR TITLE
Enable soft-newlines to be added using SHIFT + ENTER.

### DIFF
--- a/lib/components/fields/date-time-field/index.js
+++ b/lib/components/fields/date-time-field/index.js
@@ -109,7 +109,8 @@ var DateTimeField = _react2.default.createClass({
 
     // Set up field classes
     var fieldClassNames = (0, _classnames2.default)(_dateTimeField2.default.base, _defineProperty({}, '' + _dateTimeField2.default.baseInline, attributes.inline));
-
+    // TODO Asses whether to remove this binding
+    /* eslint-disable react/jsx-no-bind */
     return _react2.default.createElement(
       'div',
       { className: fieldClassNames },
@@ -134,6 +135,7 @@ var DateTimeField = _react2.default.createClass({
       ),
       hasErrors ? _react2.default.createElement(_errors2.default, { errors: errors }) : null
     );
+    /* eslint-enable react/jsx-no-bind */
   }
 });
 

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -48,6 +48,10 @@ var _inlineToolbarPlugin = require('./inline-toolbar-plugin');
 
 var _inlineToolbarPlugin2 = _interopRequireDefault(_inlineToolbarPlugin);
 
+var _softNewlinesKeyboardPlugin = require('./soft-newlines-keyboard-plugin');
+
+var _softNewlinesKeyboardPlugin2 = _interopRequireDefault(_softNewlinesKeyboardPlugin);
+
 var _richTextEditor = require('./rich-text-editor.mcss');
 
 var _richTextEditor2 = _interopRequireDefault(_richTextEditor);
@@ -143,7 +147,7 @@ var RichTextEditor = _react2.default.createClass({
       allowedFormatters: inlineFormatters
     }, inline));
     // Build up the list of plugins
-    var plugins = [inlineToolbarPlugin, (0, _draftJsBlockBreakoutPlugin2.default)()];
+    var plugins = [inlineToolbarPlugin, (0, _draftJsBlockBreakoutPlugin2.default)(), (0, _softNewlinesKeyboardPlugin2.default)()];
     // Add singleLine plugin if the boxSize matches
     if (boxSize === 'single') {
       plugins = plugins.concat([singleLinePlugin]);

--- a/lib/components/ui/rich-text-editor/soft-newlines-keyboard-plugin/index.js
+++ b/lib/components/ui/rich-text-editor/soft-newlines-keyboard-plugin/index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = softNewlinesKeyboardPlugin;
+
+var _draftJs = require('draft-js');
+
+var SOFT_NEWLINE_COMMAND = 'insert-soft-newline';
+
+/**
+ * Plugin for the allowing soft newlines to be added using the keyboard
+ * @return {Object} draft-js-editor-plugin compatible object
+ */
+function softNewlinesKeyboardPlugin() {
+  return {
+    /**
+     * Check if the current key combination is `Shift + Enter`
+     *
+     * @param  {KeyboardEvent} e Synthetic keyboard event from draft-js
+     * @return {Command} String command based on the keyboard event
+     */
+    keyBindingFn: function keyBindingFn(e) {
+      // ENTER
+      if (e.keyCode === 13 && e.shiftKey) {
+        return SOFT_NEWLINE_COMMAND;
+      }
+    },
+
+
+    /**
+     * handleKeyCommand
+     *
+     * Adjust the editorState if the soft-newline command is sent
+     *
+     * @param  {String}   command The command-as-string as passed by draft-js
+     * @param  {Function} options.getEditorState Getter for the current editorState
+     * @param  {Function} options.setEditorState Setter for the current editorState
+     * @return {Boolean} Handled or not?
+     */
+    handleKeyCommand: function handleKeyCommand(command, _ref) {
+      var getEditorState = _ref.getEditorState;
+      var setEditorState = _ref.setEditorState;
+
+      if (command === SOFT_NEWLINE_COMMAND) {
+        setEditorState(_draftJs.RichUtils.insertSoftNewline(getEditorState()));
+        return true;
+      }
+      return false;
+    }
+  };
+}

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -9,6 +9,7 @@ import createBlockBreakoutPlugin from 'draft-js-block-breakout-plugin'
 import createSingleLinePlugin from 'draft-js-single-line-plugin'
 import createBlockToolbarPlugin from './block-toolbar-plugin'
 import createInlineToolbarPlugin from './inline-toolbar-plugin'
+import createSoftNewlinesKeyboardPlugin from './soft-newlines-keyboard-plugin'
 // Styles
 import styles from './rich-text-editor.mcss'
 import './tmp.css'
@@ -97,6 +98,7 @@ const RichTextEditor = React.createClass({
     let plugins = [
       inlineToolbarPlugin,
       createBlockBreakoutPlugin(),
+      createSoftNewlinesKeyboardPlugin(),
     ]
     // Add singleLine plugin if the boxSize matches
     if (boxSize === 'single') {

--- a/src/components/ui/rich-text-editor/soft-newlines-keyboard-plugin/index.js
+++ b/src/components/ui/rich-text-editor/soft-newlines-keyboard-plugin/index.js
@@ -1,0 +1,46 @@
+import {
+  RichUtils,
+} from 'draft-js'
+
+const SOFT_NEWLINE_COMMAND = 'insert-soft-newline'
+
+/**
+ * Plugin for the allowing soft newlines to be added using the keyboard
+ * @return {Object} draft-js-editor-plugin compatible object
+ */
+export default function softNewlinesKeyboardPlugin () {
+  return {
+    /**
+     * Check if the current key combination is `Shift + Enter`
+     *
+     * @param  {KeyboardEvent} e Synthetic keyboard event from draft-js
+     * @return {Command} String command based on the keyboard event
+     */
+    keyBindingFn (e) {
+      // ENTER
+      if (e.keyCode === 13 && e.shiftKey) {
+        return SOFT_NEWLINE_COMMAND
+      }
+    },
+
+    /**
+     * handleKeyCommand
+     *
+     * Adjust the editorState if the soft-newline command is sent
+     *
+     * @param  {String}   command The command-as-string as passed by draft-js
+     * @param  {Function} options.getEditorState Getter for the current editorState
+     * @param  {Function} options.setEditorState Setter for the current editorState
+     * @return {Boolean} Handled or not?
+     */
+    handleKeyCommand: function handleKeyCommand (command, { getEditorState, setEditorState }) {
+      if (command === SOFT_NEWLINE_COMMAND) {
+        setEditorState(
+          RichUtils.insertSoftNewline(getEditorState())
+        )
+        return true
+      }
+      return false
+    },
+  }
+}


### PR DESCRIPTION
Done through the `softNewlinesKeyboardPlugin`, which is included as an internal plugin until we can extract.

These are included in the output data as `\n`, so to render them we’ll need to be up to at least this ref in `formalist`: https://github.com/icelab/formalist/commit/11cf69d27c2bfa35e7e072d7a80b664d16208d3f