### PR TITLE
Use file previews for all new uploads

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -318,6 +318,7 @@ var MultiUploadField = _react2.default.createClass({
 
     // apply the 'original_url' to existing `fileAttributes`
     copy.fileAttributes['original_url'] = this.buildPath(upload_url, response.path);
+    copy.fileAttributes['thumbnail_url'] = fileObject.file.preview;
 
     var files = this.state.files.slice(0);
     var indexOfFile = files.findIndex(function (file) {
@@ -354,15 +355,17 @@ var MultiUploadField = _react2.default.createClass({
 
   /**
    * normaliseFileExport
-   * Remove 'file_name' and 'original_url' from the fileObject.fileAttributes object
+   * Remove 'file_name', 'original_url', 'thumbnail_url' from the fileObject.fileAttributes object
    * return the object
    * @param {object} obj
    */
 
   normaliseFileExport: function normaliseFileExport(obj) {
+    var keysToRemove = ['file_name', 'original_url', 'thumbnail_url'];
     var copy = Object.assign({}, obj.fileAttributes);
-    delete copy.file_name;
-    delete copy.original_url;
+    keysToRemove.forEach(function (key) {
+      delete copy[key];
+    });
     return copy;
   },
 
@@ -748,15 +751,14 @@ var MultiUploadField = _react2.default.createClass({
    * renderThumbnail
    * Return a thumbnail image based on `thumbnail_url` or building one from 'original_url'
    * @param  {string} thumbnail_url
-   * @param  {string} original_url
    * @param  {string} file_name
    * @return {vnode}
    */
 
-  renderThumbnail: function renderThumbnail(thumbnail_url, original_url, file_name) {
-    if (!thumbnail_url && !original_url) return;
+  renderThumbnail: function renderThumbnail(thumbnail_url, file_name) {
+    if (!thumbnail_url) return;
 
-    return _react2.default.createElement('img', { src: thumbnail_url || this.buildThumbnailPath(original_url, '50x'), alt: file_name });
+    return _react2.default.createElement('img', { src: thumbnail_url, alt: file_name });
   },
 
 
@@ -819,7 +821,7 @@ var MultiUploadField = _react2.default.createClass({
     var preview = file.preview;
 
     var hasThumbnail = (0, _utils.hasImageFormatType)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(preview, null, file_name) : null;
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(preview, file_name) : null;
 
     var currentProgress = {
       width: progress > 0 ? progress + '%' : '0%'
@@ -890,7 +892,7 @@ var MultiUploadField = _react2.default.createClass({
     var original_url = fileAttributes.original_url;
 
     var hasThumbnail = thumbnail_url != null || (0, _utils.hasImageFormatType)(file_name);
-    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, original_url, file_name) : null;
+    var thumbnailImage = hasThumbnail ? this.renderThumbnail(thumbnail_url, file_name) : null;
 
     return _react2.default.createElement(
       'div',

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -253,6 +253,7 @@ const MultiUploadField = React.createClass({
 
     // apply the 'original_url' to existing `fileAttributes`
     copy.fileAttributes['original_url'] = this.buildPath(upload_url, response.path)
+    copy.fileAttributes['thumbnail_url'] = fileObject.file.preview
 
     let files = this.state.files.slice(0)
     const indexOfFile = files.findIndex(file => file.uid === fileObject.uid)
@@ -287,15 +288,19 @@ const MultiUploadField = React.createClass({
 
   /**
    * normaliseFileExport
-   * Remove 'file_name' and 'original_url' from the fileObject.fileAttributes object
+   * Remove 'file_name', 'original_url', 'thumbnail_url' from the fileObject.fileAttributes object
    * return the object
    * @param {object} obj
    */
 
   normaliseFileExport (obj) {
+    const keysToRemove = [
+      'file_name', 'original_url', 'thumbnail_url',
+    ]
     let copy = Object.assign({}, obj.fileAttributes)
-    delete copy.file_name
-    delete copy.original_url
+    keysToRemove.forEach((key) => {
+      delete copy[key]
+    })
     return copy
   },
 
@@ -641,16 +646,15 @@ const MultiUploadField = React.createClass({
    * renderThumbnail
    * Return a thumbnail image based on `thumbnail_url` or building one from 'original_url'
    * @param  {string} thumbnail_url
-   * @param  {string} original_url
    * @param  {string} file_name
    * @return {vnode}
    */
 
-  renderThumbnail (thumbnail_url, original_url, file_name) {
-    if (!thumbnail_url && !original_url) return
+  renderThumbnail (thumbnail_url, file_name) {
+    if (!thumbnail_url) return
 
     return (
-      <img src={thumbnail_url || this.buildThumbnailPath(original_url, '50x')} alt={file_name} />
+      <img src={thumbnail_url} alt={file_name} />
     )
   },
 
@@ -705,7 +709,7 @@ const MultiUploadField = React.createClass({
     const {preview} = file
     const hasThumbnail = hasImageFormatType(file_name)
     const thumbnailImage = hasThumbnail
-      ? this.renderThumbnail(preview, null, file_name)
+      ? this.renderThumbnail(preview, file_name)
       : null
 
     let currentProgress = {
@@ -767,7 +771,7 @@ const MultiUploadField = React.createClass({
     const {file_name, thumbnail_url, original_url} = fileAttributes
     const hasThumbnail = (thumbnail_url != null) || hasImageFormatType(file_name)
     const thumbnailImage = hasThumbnail
-      ? this.renderThumbnail(thumbnail_url, original_url, file_name)
+      ? this.renderThumbnail(thumbnail_url, file_name)
       : null
 
     return (


### PR DESCRIPTION
Always render newly uploaded thumbnails using the file blob URL. Fixes #107.