### PR TITLE
Unset date time values if either date or time is empty after a change

### DIFF
--- a/lib/components/ui/date-picker/index.js
+++ b/lib/components/ui/date-picker/index.js
@@ -71,6 +71,10 @@ var DatePicker = function (_React$Component) {
         var storedValue = compressDate(value);
         _this.props.onChange(storedValue);
       } else {
+        // Pass the value back if it’s empty
+        if (value === "") {
+          _this.props.onChange(value);
+        }
         _this.setState({
           value: value
         }, _this.showCurrentDate);
@@ -120,7 +124,7 @@ var DatePicker = function (_React$Component) {
         "div",
         { className: className, __source: {
             fileName: _jsxFileName,
-            lineNumber: 110
+            lineNumber: 114
           },
           __self: this
         },
@@ -134,7 +138,7 @@ var DatePicker = function (_React$Component) {
             closeOnOutsideClick: true,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 111
+              lineNumber: 115
             },
             __self: this
           },
@@ -148,7 +152,7 @@ var DatePicker = function (_React$Component) {
             "data-field-input": "date",
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 118
+              lineNumber: 122
             },
             __self: this
           }),
@@ -156,7 +160,7 @@ var DatePicker = function (_React$Component) {
             "div",
             { className: styles.daypickerContainer, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 127
+                lineNumber: 131
               },
               __self: this
             },
@@ -175,7 +179,7 @@ var DatePicker = function (_React$Component) {
               onDayClick: this.onDayClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 128
+                lineNumber: 132
               },
               __self: this
             })

--- a/lib/components/ui/date-time-picker/index.js
+++ b/lib/components/ui/date-time-picker/index.js
@@ -46,8 +46,15 @@ var DateTimePicker = function (_React$Component) {
         } else {
           _this.dateTime = parsedDate;
         }
+        _this.setState({
+          date: _this.dateTime.format(dateFormats.date)
+        }, _this.onChange);
+      } else {
+        // Handle invalid or blank values
+        _this.setState({
+          date: null
+        }, _this.onChange);
       }
-      _this.onChange();
     };
 
     _this.onTimeChange = function (time) {
@@ -62,12 +69,27 @@ var DateTimePicker = function (_React$Component) {
         } else {
           _this.dateTime = parsedTime;
         }
+        _this.setState({
+          time: _this.dateTime.format(dateFormats.time)
+        }, _this.onChange);
+      } else {
+        // Handle invalid or blank values
+        _this.setState({
+          time: null
+        }, _this.onChange);
       }
-      _this.onChange();
     };
 
     _this.onChange = function () {
-      _this.props.onChange(_this.dateTime.format(dateFormats.utc));
+      var _this$state = _this.state,
+          date = _this$state.date,
+          time = _this$state.time;
+
+      if (date && time) {
+        _this.props.onChange(_this.dateTime.format(dateFormats.utc));
+      } else {
+        _this.props.onChange(null);
+      }
     };
 
     if (props.value) {
@@ -127,7 +149,7 @@ var DateTimePicker = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 110
+            lineNumber: 141
           },
           __self: this
         },
@@ -135,7 +157,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.datePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 111
+              lineNumber: 142
             },
             __self: this
           },
@@ -147,7 +169,7 @@ var DateTimePicker = function (_React$Component) {
             onChange: this.onDateChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 112
+              lineNumber: 143
             },
             __self: this
           })
@@ -156,7 +178,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.timePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 120
+              lineNumber: 151
             },
             __self: this
           },
@@ -166,7 +188,7 @@ var DateTimePicker = function (_React$Component) {
             onChange: this.onTimeChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 121
+              lineNumber: 152
             },
             __self: this
           })

--- a/src/components/ui/date-picker/index.js
+++ b/src/components/ui/date-picker/index.js
@@ -73,6 +73,10 @@ class DatePicker extends React.Component {
       let storedValue = compressDate(value);
       this.props.onChange(storedValue);
     } else {
+      // Pass the value back if it’s empty
+      if (value === "") {
+        this.props.onChange(value);
+      }
       this.setState(
         {
           value

--- a/src/components/ui/date-time-picker/index.js
+++ b/src/components/ui/date-time-picker/index.js
@@ -72,8 +72,21 @@ class DateTimePicker extends React.Component {
       } else {
         this.dateTime = parsedDate;
       }
+      this.setState(
+        {
+          date: this.dateTime.format(dateFormats.date)
+        },
+        this.onChange
+      );
+    } else {
+      // Handle invalid or blank values
+      this.setState(
+        {
+          date: null
+        },
+        this.onChange
+      );
     }
-    this.onChange();
   };
 
   /**
@@ -92,12 +105,30 @@ class DateTimePicker extends React.Component {
       } else {
         this.dateTime = parsedTime;
       }
+      this.setState(
+        {
+          time: this.dateTime.format(dateFormats.time)
+        },
+        this.onChange
+      );
+    } else {
+      // Handle invalid or blank values
+      this.setState(
+        {
+          time: null
+        },
+        this.onChange
+      );
     }
-    this.onChange();
   };
 
   onChange = () => {
-    this.props.onChange(this.dateTime.format(dateFormats.utc));
+    const { date, time } = this.state;
+    if (date && time) {
+      this.props.onChange(this.dateTime.format(dateFormats.utc));
+    } else {
+      this.props.onChange(null);
+    }
   };
 
   render() {


### PR DESCRIPTION
Fixes #103. We now pass through a null value if the field is emptied, which is then reflected in the AST and the serialised data.