### PR TITLE
Pass presign attributes to endpoint

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -626,7 +626,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 949
+          lineNumber: 959
         },
         __self: this
       });
@@ -724,7 +724,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1084
+            lineNumber: 1094
           },
           __self: this
         },
@@ -733,7 +733,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1089
+              lineNumber: 1099
             },
             __self: this
           },
@@ -742,13 +742,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1090
+                lineNumber: 1100
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1091
+                lineNumber: 1101
               },
               __self: this
             })
@@ -765,7 +765,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1099
+                lineNumber: 1109
               },
               __self: this
             },
@@ -773,7 +773,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1108
+              lineNumber: 1118
             },
             __self: this
           }) : null
@@ -1367,15 +1367,29 @@ var _initialiseProps = function _initialiseProps() {
   this.buildPath = function (url, path) {
     var dimension = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "original";
 
-    var pattern = /([^/]*)$/;
-    var splitPath = path.split(pattern);
-    return url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1];
+    var _ref2 = _this6.context.globalConfig || {},
+        uploader = _ref2.uploader;
+
+    if (uploader === "attache") {
+      var pattern = /([^/]*)$/;
+      var splitPath = path.split(pattern);
+      return url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1];
+    } else {
+      return url + "/" + path;
+    }
   };
 
   this.buildThumbnailPath = function (original_url) {
     var dimension = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "50x";
 
-    return original_url.replace("original", dimension);
+    var _ref3 = _this6.context.globalConfig || {},
+        uploader = _ref3.uploader;
+
+    if (uploader === "attache") {
+      return original_url.replace("original", dimension);
+    } else {
+      return original_url;
+    }
   };
 
   this.renderCustomTemplate = function (fileObject, index, config, attribute) {
@@ -1424,7 +1438,7 @@ var _initialiseProps = function _initialiseProps() {
         onDrop: _this6.onDrop,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1053
+          lineNumber: 1063
         },
         __self: _this6
       },

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -305,10 +305,10 @@ var MultiUploadField = function (_React$Component2) {
     var _props$attributes = props.attributes,
         presign_url = _props$attributes.presign_url,
         presign_options = _props$attributes.presign_options;
-    var _context$globalConfig = context.globalConfig,
-        csrfToken = _context$globalConfig.csrfToken,
-        uploader = _context$globalConfig.uploader;
 
+    var _ref = context.globalConfig || {},
+        csrfToken = _ref.csrfToken,
+        uploader = _ref.uploader;
 
     var allowMultipleFiles = props.multiple || props.attributes.multiple;
     value = value ? value.toJS() : value;
@@ -340,7 +340,7 @@ var MultiUploadField = function (_React$Component2) {
     // Switch uploaders if specified
     _this5.uploader = s3Upload;
     _this5.uploaderPresignArgs = [presign_url, csrfToken, presign_options];
-    if (context.globalConfig && context.globalConfig.uploader === "attache") {
+    if (uploader === "attache") {
       _this5.uploader = attacheUpload;
       _this5.uploaderPresignArgs = [presign_url, csrfToken];
     }
@@ -626,7 +626,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 950
+          lineNumber: 949
         },
         __self: this
       });
@@ -724,7 +724,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1085
+            lineNumber: 1084
           },
           __self: this
         },
@@ -733,7 +733,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1090
+              lineNumber: 1089
             },
             __self: this
           },
@@ -742,13 +742,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1091
+                lineNumber: 1090
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1092
+                lineNumber: 1091
               },
               __self: this
             })
@@ -765,7 +765,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1100
+                lineNumber: 1099
               },
               __self: this
             },
@@ -773,7 +773,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1109
+              lineNumber: 1108
             },
             __self: this
           }) : null
@@ -959,11 +959,6 @@ var _initialiseProps = function _initialiseProps() {
     var onProgress = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : noOp;
 
     if (!fileObject) return;
-    var _props$attributes2 = _this6.props.attributes,
-        presign_url = _props$attributes2.presign_url,
-        presign_options = _props$attributes2.presign_options;
-    var csrfToken = _this6.context.globalConfig.csrfToken;
-
     var upload_url = void 0;
 
     // Push into uploadQueue
@@ -1151,7 +1146,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 753
+          lineNumber: 752
         },
         __self: _this6
       },
@@ -1160,7 +1155,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 755
+            lineNumber: 754
           },
           __self: _this6
         },
@@ -1168,7 +1163,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 756
+              lineNumber: 755
             },
             __self: _this6
           },
@@ -1182,7 +1177,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 757
+              lineNumber: 756
             },
             __self: _this6
           },
@@ -1197,7 +1192,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 778
+          lineNumber: 777
         },
         __self: _this6
       },
@@ -1215,7 +1210,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 797
+          lineNumber: 796
         },
         __self: _this6
       },
@@ -1224,7 +1219,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 798
+            lineNumber: 797
           },
           __self: _this6
         },
@@ -1236,7 +1231,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 799
+            lineNumber: 798
           },
           __self: _this6
         },
@@ -1244,7 +1239,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 800
+              lineNumber: 799
             },
             __self: _this6
           },
@@ -1258,7 +1253,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 801
+              lineNumber: 800
             },
             __self: _this6
           },
@@ -1273,7 +1268,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 822
+          lineNumber: 821
         },
         __self: _this6
       },
@@ -1286,7 +1281,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 839
+        lineNumber: 838
       },
       __self: _this6
     });
@@ -1305,7 +1300,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 866
+          lineNumber: 865
         },
         __self: _this6
       },
@@ -1313,7 +1308,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 867
+            lineNumber: 866
           },
           __self: _this6
         },
@@ -1323,7 +1318,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 868
+            lineNumber: 867
           },
           __self: _this6
         },
@@ -1351,7 +1346,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 895
+          lineNumber: 894
         },
         __self: _this6
       },
@@ -1359,7 +1354,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 896
+            lineNumber: 895
           },
           __self: _this6
         },
@@ -1429,7 +1424,7 @@ var _initialiseProps = function _initialiseProps() {
         onDrop: _this6.onDrop,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1054
+          lineNumber: 1053
         },
         __self: _this6
       },

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -302,6 +302,13 @@ var MultiUploadField = function (_React$Component2) {
     _initialiseProps.call(_this5);
 
     var value = props.value;
+    var _props$attributes = props.attributes,
+        presign_url = _props$attributes.presign_url,
+        presign_options = _props$attributes.presign_options;
+    var _context$globalConfig = context.globalConfig,
+        csrfToken = _context$globalConfig.csrfToken,
+        uploader = _context$globalConfig.uploader;
+
 
     var allowMultipleFiles = props.multiple || props.attributes.multiple;
     value = value ? value.toJS() : value;
@@ -332,8 +339,10 @@ var MultiUploadField = function (_React$Component2) {
 
     // Switch uploaders if specified
     _this5.uploader = s3Upload;
+    _this5.uploaderPresignArgs = [presign_url, csrfToken, presign_options];
     if (context.globalConfig && context.globalConfig.uploader === "attache") {
       _this5.uploader = attacheUpload;
+      _this5.uploaderPresignArgs = [presign_url, csrfToken];
     }
     return _this5;
   }
@@ -617,7 +626,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 944
+          lineNumber: 950
         },
         __self: this
       });
@@ -715,7 +724,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1079
+            lineNumber: 1085
           },
           __self: this
         },
@@ -724,7 +733,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1084
+              lineNumber: 1090
             },
             __self: this
           },
@@ -733,13 +742,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1085
+                lineNumber: 1091
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1086
+                lineNumber: 1092
               },
               __self: this
             })
@@ -756,7 +765,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1094
+                lineNumber: 1100
               },
               __self: this
             },
@@ -764,7 +773,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1103
+              lineNumber: 1109
             },
             __self: this
           }) : null
@@ -786,6 +795,7 @@ MultiUploadField.propTypes = {
     permitted_file_type_message: PropTypes.string,
     permitted_file_type_regex: PropTypes.string,
     presign_url: PropTypes.string,
+    presign_options: PropTypes.object,
     render_uploaded_as: PropTypes.string,
     upload_action_label: PropTypes.string,
     upload_prompt: PropTypes.string
@@ -949,7 +959,9 @@ var _initialiseProps = function _initialiseProps() {
     var onProgress = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : noOp;
 
     if (!fileObject) return;
-    var presign_url = _this6.props.attributes.presign_url;
+    var _props$attributes2 = _this6.props.attributes,
+        presign_url = _props$attributes2.presign_url,
+        presign_options = _props$attributes2.presign_options;
     var csrfToken = _this6.context.globalConfig.csrfToken;
 
     var upload_url = void 0;
@@ -957,7 +969,7 @@ var _initialiseProps = function _initialiseProps() {
     // Push into uploadQueue
     _this6.addToUploadQueue(fileObject.uid);
 
-    _this6.uploader.presign(presign_url, csrfToken).then(function (presignResponse) {
+    _this6.uploader.presign.apply(_this6, _this6.uploaderPresignArgs).then(function (presignResponse) {
       // assign the return 'url' to upload_url so
       // we can create paths to the file
       upload_url = presignResponse.url;
@@ -1139,7 +1151,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 747
+          lineNumber: 753
         },
         __self: _this6
       },
@@ -1148,7 +1160,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 749
+            lineNumber: 755
           },
           __self: _this6
         },
@@ -1156,7 +1168,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 750
+              lineNumber: 756
             },
             __self: _this6
           },
@@ -1170,7 +1182,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 751
+              lineNumber: 757
             },
             __self: _this6
           },
@@ -1185,7 +1197,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 772
+          lineNumber: 778
         },
         __self: _this6
       },
@@ -1203,7 +1215,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 791
+          lineNumber: 797
         },
         __self: _this6
       },
@@ -1212,7 +1224,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 792
+            lineNumber: 798
           },
           __self: _this6
         },
@@ -1224,7 +1236,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 793
+            lineNumber: 799
           },
           __self: _this6
         },
@@ -1232,7 +1244,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 794
+              lineNumber: 800
             },
             __self: _this6
           },
@@ -1246,7 +1258,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 795
+              lineNumber: 801
             },
             __self: _this6
           },
@@ -1261,7 +1273,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 816
+          lineNumber: 822
         },
         __self: _this6
       },
@@ -1274,7 +1286,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 833
+        lineNumber: 839
       },
       __self: _this6
     });
@@ -1293,7 +1305,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 860
+          lineNumber: 866
         },
         __self: _this6
       },
@@ -1301,7 +1313,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 861
+            lineNumber: 867
           },
           __self: _this6
         },
@@ -1311,7 +1323,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 862
+            lineNumber: 868
           },
           __self: _this6
         },
@@ -1339,7 +1351,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 889
+          lineNumber: 895
         },
         __self: _this6
       },
@@ -1347,7 +1359,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 890
+            lineNumber: 896
           },
           __self: _this6
         },
@@ -1417,7 +1429,7 @@ var _initialiseProps = function _initialiseProps() {
         onDrop: _this6.onDrop,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1048
+          lineNumber: 1054
         },
         __self: _this6
       },

--- a/lib/utils/s3-upload/index.js
+++ b/lib/utils/s3-upload/index.js
@@ -141,7 +141,6 @@ function parseMetadata(file) {
       size: file.size,
       content_type: file.type
     };
-    var isImage = file.type.match("image.*");
 
     var reader = new FileReader();
     reader.onload = function (f) {

--- a/lib/utils/s3-upload/index.js
+++ b/lib/utils/s3-upload/index.js
@@ -317,9 +317,9 @@ function upload(res, fileObject) {
  * @param  {Promise}
  */
 
-function presignRequest(presignUrl, token) {
+function presignRequest(presignUrl, token, presignOptions) {
   return new Promise(function (resolve, reject) {
-    request.post(presignUrl).set({
+    request.post(presignUrl).send(presignOptions).set({
       Accept: "application/json",
       "Content-Type": "application/json",
       "X-CSRF-Token": token
@@ -342,10 +342,11 @@ function presignRequest(presignUrl, token) {
  */
 
 function presign(presignUrl, token) {
-  var fn = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : presignRequest;
+  var presignOptions = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+  var fn = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : presignRequest;
 
   return new Promise(function (resolve, reject) {
-    fn(presignUrl, token).then(responseStatus).then(parseJSON).then(function (res) {
+    fn(presignUrl, token, presignOptions).then(responseStatus).then(parseJSON).then(function (res) {
       resolve(res);
     }).catch(function (err) {
       reject(err);

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -913,16 +913,21 @@ class MultiUploadField extends React.Component {
    */
 
   buildPath = (url, path, dimension = "original") => {
-    const pattern = /([^/]*)$/;
-    const splitPath = path.split(pattern);
-    return (
-      url.replace("/upload", "/view") +
-      "/" +
-      splitPath[0] +
-      dimension +
-      "/" +
-      splitPath[1]
-    );
+    const { uploader } = this.context.globalConfig || {};
+    if (uploader === "attache") {
+      const pattern = /([^/]*)$/;
+      const splitPath = path.split(pattern);
+      return (
+        url.replace("/upload", "/view") +
+        "/" +
+        splitPath[0] +
+        dimension +
+        "/" +
+        splitPath[1]
+      );
+    } else {
+      return `${url}/${path}`;
+    }
   };
 
   /**
@@ -934,7 +939,12 @@ class MultiUploadField extends React.Component {
    */
 
   buildThumbnailPath = (original_url, dimension = "50x") => {
-    return original_url.replace("original", dimension);
+    const { uploader } = this.context.globalConfig || {};
+    if (uploader === "attache") {
+      return original_url.replace("original", dimension);
+    } else {
+      return original_url;
+    }
   };
 
   /**

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -197,7 +197,7 @@ class MultiUploadField extends React.Component {
     super(props, context);
     let { value } = props;
     const { presign_url, presign_options } = props.attributes;
-    const { csrfToken, uploader } = context.globalConfig;
+    const { csrfToken, uploader } = context.globalConfig || {};
 
     const allowMultipleFiles = props.multiple || props.attributes.multiple;
     value = value ? value.toJS() : value;
@@ -229,7 +229,7 @@ class MultiUploadField extends React.Component {
     // Switch uploaders if specified
     this.uploader = s3Upload;
     this.uploaderPresignArgs = [presign_url, csrfToken, presign_options];
-    if (context.globalConfig && context.globalConfig.uploader === "attache") {
+    if (uploader === "attache") {
       this.uploader = attacheUpload;
       this.uploaderPresignArgs = [presign_url, csrfToken];
     }
@@ -488,14 +488,13 @@ class MultiUploadField extends React.Component {
 
   uploadFile = (fileObject, onProgress = noOp) => {
     if (!fileObject) return;
-    const { presign_url, presign_options } = this.props.attributes;
-    const { csrfToken } = this.context.globalConfig;
     let upload_url;
 
     // Push into uploadQueue
     this.addToUploadQueue(fileObject.uid);
 
-    this.uploader.presign.apply(this, this.uploaderPresignArgs)
+    this.uploader.presign
+      .apply(this, this.uploaderPresignArgs)
       .then(presignResponse => {
         // assign the return 'url' to upload_url so
         // we can create paths to the file

--- a/src/components/fields/multi-upload-field/styles.js
+++ b/src/components/fields/multi-upload-field/styles.js
@@ -167,8 +167,7 @@ export const copyUrlButton = css`
   }
 `;
 
-export const copyUrlButtonCopied = css`
-`;
+export const copyUrlButtonCopied = css``;
 
 export const copyUrlButtonText = css`
   ${colours.darkBlendBackground};

--- a/src/utils/s3-upload/index.js
+++ b/src/utils/s3-upload/index.js
@@ -317,10 +317,11 @@ function upload(res, fileObject, showProgress = noOp, fn = uploadRequest) {
  * @param  {Promise}
  */
 
-function presignRequest(presignUrl, token) {
+function presignRequest(presignUrl, token, presignOptions) {
   return new Promise((resolve, reject) => {
     request
       .post(presignUrl)
+      .send(presignOptions)
       .set({
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -344,9 +345,9 @@ function presignRequest(presignUrl, token) {
  * @param  {Promise}
  */
 
-function presign(presignUrl, token, fn = presignRequest) {
+function presign(presignUrl, token, presignOptions = {}, fn = presignRequest) {
   return new Promise((resolve, reject) => {
-    fn(presignUrl, token)
+    fn(presignUrl, token, presignOptions)
       .then(responseStatus)
       .then(parseJSON)
       .then(res => {

--- a/src/utils/s3-upload/index.js
+++ b/src/utils/s3-upload/index.js
@@ -141,7 +141,6 @@ function parseMetadata(file) {
       size: file.size,
       content_type: file.type
     };
-    const isImage = file.type.match("image.*");
 
     const reader = new FileReader();
     reader.onload = function(f) {


### PR DESCRIPTION
Adds the `presign_options` value passed to an upload field through its `attributes` to the POST payload for the `presign` endpoint.