### PR TITLE
Get duration for audio/video files at upload time

### DIFF
--- a/lib/utils/s3-upload/index.js
+++ b/lib/utils/s3-upload/index.js
@@ -130,11 +130,27 @@ function formData(as, file, fields) {
 }
 
 /**
+ * Determine the file type
+ * @param {FileObject} file Uploaded file object
+ * @return {Mixed} Type as simple string or false if no match
+ */
+function fileType(file) {
+  if (file.type.match("image.*")) {
+    return "image";
+  } else if (file.type.match("video.*")) {
+    return "video";
+  } else if (file.type.match("audio.*")) {
+    return "audio";
+  }
+  return false;
+}
+
+/**
  * Parse file metadata
  * @param {FileObject} file
  */
 function parseMetadata(file) {
-  var isImage = file.type.match("image.*");
+  var type = fileType(file);
 
   return new Promise(function (resolve, reject) {
     var metadata = {
@@ -142,31 +158,123 @@ function parseMetadata(file) {
       content_type: file.type
     };
 
-    var reader = new FileReader();
-    reader.onload = function (f) {
-      if (isImage) {
-        var image = new Image();
-
-        image.onload = function () {
-          metadata.height = image.height;
-          metadata.width = image.width;
-
-          correctImageMetadata(file, metadata).then(function (data) {
-            resolve(data);
-          });
-        };
-        image.onerror = function (err) {
-          reject(err);
-        };
-        image.src = f.target.result;
-      } else {
+    switch (type) {
+      case "image":
+        parseImageMetadata(file).then(function (data) {
+          return resolve(Object.assign({}, metadata, data));
+        }).catch(function (err) {
+          return reject(err);
+        });
+        break;
+      case "audio":
+        parseAudioMetadata(file).then(function (data) {
+          return resolve(Object.assign({}, metadata, data));
+        }).catch(function (err) {
+          return reject(err);
+        });
+        break;
+      case "video":
+        parseVideoMetadata(file).then(function (data) {
+          return resolve(Object.assign({}, metadata, data));
+        }).catch(function (err) {
+          return reject(err);
+        });
+        break;
+      default:
         resolve(metadata);
-      }
-    };
-    reader.onerror = function (err) {
-      reject(err);
-    };
+        break;
+    }
+  });
+}
+
+/**
+ * Parse metadata for images
+ * @param {FileObject} file Uploaded image file
+ * @return {Promise}
+ */
+function parseImageMetadata(file) {
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReader();
+    reader.addEventListener("load", function onReaderLoad(f) {
+      var image = new Image();
+
+      image.addEventListener("load", function onImageLoad() {
+        var metadata = {
+          height: image.height,
+          width: image.width
+        };
+        correctImageMetadata(file, metadata).then(function (data) {
+          resolve(data);
+        });
+      });
+
+      image.addEventListener("error", function onImageError(err) {
+        reject(err);
+      });
+
+      image.src = f.target.result;
+    });
     reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Parse metadata for videos
+ * @param {FileObject} file Uploaded video file
+ * @return {Promise}
+ */
+function parseVideoMetadata(file) {
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReader();
+    reader.addEventListener("load", function onReaderLoad(f) {
+      // Build object URL from file blob
+      var blob = new Blob([f.target.result], { type: file.type });
+      var url = (URL || webkitURL).createObjectURL(blob);
+      var video = document.createElement("video");
+      video.preload = "metadata";
+
+      video.addEventListener("loadedmetadata", function onVideoLoad() {
+        var duration = video.duration;
+        resolve({ duration: duration });
+      });
+
+      video.addEventListener("error", function onVideoError(err) {
+        reject(err);
+      });
+
+      video.src = url;
+    });
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+/**
+ * Parse metadata for audio files
+ * @param {FileObject} file Uploaded audio file
+ * @return {Promise}
+ */
+function parseAudioMetadata(file) {
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReader();
+    reader.addEventListener("load", function onReaderLoad(f) {
+      // Build object URL from file blob
+      var blob = new Blob([f.target.result], { type: file.type });
+      var url = (URL || webkitURL).createObjectURL(blob);
+      var audio = document.createElement("audio");
+      audio.preload = "metadata";
+
+      audio.addEventListener("loadedmetadata", function onAudioLoad() {
+        var duration = audio.duration;
+        resolve({ duration: duration });
+      });
+
+      audio.addEventListener("error", function onAudioError(err) {
+        reject(err);
+      });
+
+      audio.src = url;
+    });
+    reader.readAsArrayBuffer(file);
   });
 }
 


### PR DESCRIPTION
Addresses #134. We do this by loading the file into an `<audio>` or `<video>` element and fetching the duration after its metadata is loaded.

The process is pretty similar to what we had in place for images, but the key difference is that we load the file using `readAsArrayBuffer(file)` rather than `readAsDataURL(file)` and then use the resultant data to create a `Blob` and an `ObjectURL` from that `Blob. This is important because `readAsDataURL` loads the entire file into memory and thus it can crash everything when you try to upload a large video or audio file.

Data should come back in this shape:

```
post[files][][content_type]: video/mp4
post[files][][size]: 11115458
post[files][][path]: upload/path/video.m4
post[files][][duration]: 45.5
```

Where `duration` is in seconds.