### PR TITLE
Support custom option controls

### DIFF
--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -104,6 +104,7 @@ var SearchMultiSelectionField = function (_Component) {
     _this2.onSelectorBlur = _this2.onSelectorBlur.bind(_this2);
     _this2.onSelectorFocus = _this2.onSelectorFocus.bind(_this2);
     _this2.onSelectorQueryChange = _this2.onSelectorQueryChange.bind(_this2);
+    _this2.fetchSelectionsData = _this2.fetchSelectionsData.bind(_this2);
     return _this2;
   }
 
@@ -122,9 +123,20 @@ var SearchMultiSelectionField = function (_Component) {
   }, {
     key: "componentWillMount",
     value: function componentWillMount() {
+      this.fetchSelectionsData();
+    }
+
+    /**
+     * fetchSelectionsData
+     * Do an XHR request for the additional selections data
+     * @return {Null}
+     */
+
+  }, {
+    key: "fetchSelectionsData",
+    value: function fetchSelectionsData() {
       var _this3 = this;
 
-      // Do an XHR request for the additional selection data
       var _props = this.props,
           attributes = _props.attributes,
           value = _props.value;
@@ -360,7 +372,7 @@ var SearchMultiSelectionField = function (_Component) {
           "data-field-type": "search-multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 271
+            lineNumber: 280
           },
           __self: this
         },
@@ -368,13 +380,13 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 276
+              lineNumber: 285
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 277
+              lineNumber: 286
             },
             __self: this
           })
@@ -383,7 +395,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 279
+              lineNumber: 288
             },
             __self: this
           },
@@ -395,7 +407,7 @@ var SearchMultiSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 280
+                lineNumber: 289
               },
               __self: this
             },
@@ -403,7 +415,7 @@ var SearchMultiSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 285
+                  lineNumber: 294
                 },
                 __self: this
               },
@@ -424,7 +436,7 @@ var SearchMultiSelectionField = function (_Component) {
                 testId: "search-multi-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 291
+                  lineNumber: 300
                 },
                 __self: this
               },
@@ -432,7 +444,7 @@ var SearchMultiSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 302
+                    lineNumber: 311
                   },
                   __self: this
                 },
@@ -455,7 +467,7 @@ var SearchMultiSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 305
+                  lineNumber: 314
                 },
                 __self: this
               })
@@ -466,7 +478,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 325
+              lineNumber: 334
             },
             __self: this
           },
@@ -474,14 +486,14 @@ var SearchMultiSelectionField = function (_Component) {
             Sortable,
             { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 326
+                lineNumber: 335
               },
               __self: this
             },
             selections.map(function (option, index) {
-              return React.createElement(Selection, { key: index + "_" + option.id, option: option, __source: {
+              return React.createElement(Selection, { key: index + "_" + option.id, option: option, fetchSelectionsData: _this4.fetchSelectionsData, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 328
+                  lineNumber: 337
                 },
                 __self: _this4
               });
@@ -490,7 +502,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 333
+            lineNumber: 342
           },
           __self: this
         }) : null

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -336,6 +336,7 @@ var SearchMultiSelectionField = function (_Component) {
       var placeholder = attributes.placeholder,
           selector_label = attributes.selector_label,
           render_option_as = attributes.render_option_as,
+          render_option_control_as = attributes.render_option_control_as,
           render_selection_as = attributes.render_selection_as;
       var _state = this.state,
           selections = _state.selections,
@@ -349,12 +350,16 @@ var SearchMultiSelectionField = function (_Component) {
 
       // Determine the selection/selected display components
       var Option = SelectDefault;
+      var OptionControl = null;
       var Selection = SelectDefault;
 
       // Extract them from the passed `config.components` if it exists
       if (config.components) {
         if (render_option_as) {
           Option = extractComponent(config.components, render_option_as) || Option;
+        }
+        if (render_option_control_as) {
+          OptionControl = extractComponent(config.components, render_option_control_as) || OptionControl;
         }
         if (render_selection_as) {
           Selection = extractComponent(config.components, render_selection_as) || Selection;
@@ -372,7 +377,7 @@ var SearchMultiSelectionField = function (_Component) {
           "data-field-type": "search-multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 280
+            lineNumber: 286
           },
           __self: this
         },
@@ -380,13 +385,13 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 285
+              lineNumber: 291
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 286
+              lineNumber: 292
             },
             __self: this
           })
@@ -395,7 +400,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 288
+              lineNumber: 294
             },
             __self: this
           },
@@ -407,7 +412,7 @@ var SearchMultiSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 289
+                lineNumber: 295
               },
               __self: this
             },
@@ -415,7 +420,7 @@ var SearchMultiSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 294
+                  lineNumber: 300
                 },
                 __self: this
               },
@@ -436,7 +441,7 @@ var SearchMultiSelectionField = function (_Component) {
                 testId: "search-multi-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 300
+                  lineNumber: 306
                 },
                 __self: this
               },
@@ -444,7 +449,7 @@ var SearchMultiSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 311
+                    lineNumber: 317
                   },
                   __self: this
                 },
@@ -459,6 +464,7 @@ var SearchMultiSelectionField = function (_Component) {
                 onFocus: this.onSelectorFocus,
                 onQueryChange: this.onSelectorQueryChange,
                 optionComponent: Option,
+                optionControlComponent: OptionControl,
                 params: attributes.search_params,
                 perPage: attributes.search_per_page,
                 query: selectorQuery,
@@ -467,7 +473,7 @@ var SearchMultiSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 314
+                  lineNumber: 320
                 },
                 __self: this
               })
@@ -478,7 +484,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 334
+              lineNumber: 341
             },
             __self: this
           },
@@ -486,14 +492,14 @@ var SearchMultiSelectionField = function (_Component) {
             Sortable,
             { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 335
+                lineNumber: 342
               },
               __self: this
             },
             selections.map(function (option, index) {
               return React.createElement(Selection, { key: index + "_" + option.id, option: option, fetchSelectionsData: _this4.fetchSelectionsData, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 337
+                  lineNumber: 344
                 },
                 __self: _this4
               });
@@ -502,7 +508,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 342
+            lineNumber: 349
           },
           __self: this
         }) : null
@@ -541,6 +547,7 @@ SearchMultiSelectionField.propTypes = {
     search_threshold: PropTypes.number,
     selector_label: PropTypes.string,
     render_option_as: PropTypes.string,
+    render_option_control_as: PropTypes.string,
     render_selection_as: PropTypes.string
   }),
   hint: PropTypes.string,

--- a/lib/components/fields/search-selection-field/index.js
+++ b/lib/components/fields/search-selection-field/index.js
@@ -92,6 +92,7 @@ var SearchSelectionField = function (_Component) {
     _this2.onSelectorBlur = _this2.onSelectorBlur.bind(_this2);
     _this2.onSelectorFocus = _this2.onSelectorFocus.bind(_this2);
     _this2.onSelectorQueryChange = _this2.onSelectorQueryChange.bind(_this2);
+    _this2.fetchSelectionData = _this2.fetchSelectionData.bind(_this2);
     return _this2;
   }
 
@@ -105,9 +106,20 @@ var SearchSelectionField = function (_Component) {
   _createClass(SearchSelectionField, [{
     key: "componentWillMount",
     value: function componentWillMount() {
+      this.fetchSelectionData();
+    }
+
+    /**
+     * fetchSelectionData
+     * Do an XHR request for the additional selection data
+     * @return {Null}
+     */
+
+  }, {
+    key: "fetchSelectionData",
+    value: function fetchSelectionData() {
       var _this3 = this;
 
-      // Do an XHR request for the additional selection data
       var _props = this.props,
           attributes = _props.attributes,
           value = _props.value;
@@ -308,7 +320,7 @@ var SearchSelectionField = function (_Component) {
           "data-field-type": "search-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 226
+            lineNumber: 235
           },
           __self: this
         },
@@ -316,13 +328,13 @@ var SearchSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 231
+              lineNumber: 240
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 232
+              lineNumber: 241
             },
             __self: this
           })
@@ -331,7 +343,7 @@ var SearchSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 234
+              lineNumber: 243
             },
             __self: this
           },
@@ -339,7 +351,7 @@ var SearchSelectionField = function (_Component) {
             "div",
             { className: styles.wrapper, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 236
+                lineNumber: 245
               },
               __self: this
             },
@@ -347,13 +359,13 @@ var SearchSelectionField = function (_Component) {
               "div",
               { className: styles.selection, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 237
+                  lineNumber: 246
                 },
                 __self: this
               },
-              React.createElement(Selection, { option: selection, __source: {
+              React.createElement(Selection, { option: selection, fetchSelectionData: this.fetchSelectionData, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 238
+                  lineNumber: 247
                 },
                 __self: this
               })
@@ -362,7 +374,7 @@ var SearchSelectionField = function (_Component) {
               "button",
               { className: styles.remove, onClick: this.onRemoveClick, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 240
+                  lineNumber: 249
                 },
                 __self: this
               },
@@ -370,7 +382,7 @@ var SearchSelectionField = function (_Component) {
                 "span",
                 { className: styles.removeText, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 241
+                    lineNumber: 250
                   },
                   __self: this
                 },
@@ -380,7 +392,7 @@ var SearchSelectionField = function (_Component) {
                 "div",
                 { className: styles.removeX, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 242
+                    lineNumber: 251
                   },
                   __self: this
                 },
@@ -395,7 +407,7 @@ var SearchSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 246
+                lineNumber: 255
               },
               __self: this
             },
@@ -403,7 +415,7 @@ var SearchSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 251
+                  lineNumber: 260
                 },
                 __self: this
               },
@@ -422,7 +434,7 @@ var SearchSelectionField = function (_Component) {
                 testId: "search-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 254
+                  lineNumber: 263
                 },
                 __self: this
               },
@@ -430,7 +442,7 @@ var SearchSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 264
+                    lineNumber: 273
                   },
                   __self: this
                 },
@@ -452,7 +464,7 @@ var SearchSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 267
+                  lineNumber: 276
                 },
                 __self: this
               })
@@ -460,7 +472,7 @@ var SearchSelectionField = function (_Component) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 285
+              lineNumber: 294
             },
             __self: this
           }) : null

--- a/lib/components/fields/search-selection-field/index.js
+++ b/lib/components/fields/search-selection-field/index.js
@@ -287,6 +287,7 @@ var SearchSelectionField = function (_Component) {
       var placeholder = attributes.placeholder,
           selector_label = attributes.selector_label,
           render_option_as = attributes.render_option_as,
+          render_option_control_as = attributes.render_option_control_as,
           render_selection_as = attributes.render_selection_as;
       var _state = this.state,
           selection = _state.selection,
@@ -300,12 +301,16 @@ var SearchSelectionField = function (_Component) {
 
       // Determine the selection/selected display components
       var Option = SelectDefault;
+      var OptionControl = null;
       var Selection = SelectDefault;
 
       // Extract them from the passed `config.components` if it exists
       if (config.components) {
         if (render_option_as) {
           Option = extractComponent(config.components, render_option_as) || Option;
+        }
+        if (render_option_control_as) {
+          OptionControl = extractComponent(config.components, render_option_control_as) || OptionControl;
         }
         if (render_selection_as) {
           Selection = extractComponent(config.components, render_selection_as) || Selection;
@@ -320,7 +325,7 @@ var SearchSelectionField = function (_Component) {
           "data-field-type": "search-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 235
+            lineNumber: 241
           },
           __self: this
         },
@@ -328,13 +333,13 @@ var SearchSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 240
+              lineNumber: 246
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 241
+              lineNumber: 247
             },
             __self: this
           })
@@ -343,7 +348,7 @@ var SearchSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 243
+              lineNumber: 249
             },
             __self: this
           },
@@ -351,7 +356,7 @@ var SearchSelectionField = function (_Component) {
             "div",
             { className: styles.wrapper, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 245
+                lineNumber: 251
               },
               __self: this
             },
@@ -359,13 +364,13 @@ var SearchSelectionField = function (_Component) {
               "div",
               { className: styles.selection, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 246
+                  lineNumber: 252
                 },
                 __self: this
               },
               React.createElement(Selection, { option: selection, fetchSelectionData: this.fetchSelectionData, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 247
+                  lineNumber: 253
                 },
                 __self: this
               })
@@ -374,7 +379,7 @@ var SearchSelectionField = function (_Component) {
               "button",
               { className: styles.remove, onClick: this.onRemoveClick, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 249
+                  lineNumber: 255
                 },
                 __self: this
               },
@@ -382,7 +387,7 @@ var SearchSelectionField = function (_Component) {
                 "span",
                 { className: styles.removeText, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 250
+                    lineNumber: 256
                   },
                   __self: this
                 },
@@ -392,7 +397,7 @@ var SearchSelectionField = function (_Component) {
                 "div",
                 { className: styles.removeX, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 251
+                    lineNumber: 257
                   },
                   __self: this
                 },
@@ -407,7 +412,7 @@ var SearchSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 255
+                lineNumber: 261
               },
               __self: this
             },
@@ -415,7 +420,7 @@ var SearchSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 260
+                  lineNumber: 266
                 },
                 __self: this
               },
@@ -434,7 +439,7 @@ var SearchSelectionField = function (_Component) {
                 testId: "search-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 263
+                  lineNumber: 269
                 },
                 __self: this
               },
@@ -442,7 +447,7 @@ var SearchSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 273
+                    lineNumber: 279
                   },
                   __self: this
                 },
@@ -457,6 +462,7 @@ var SearchSelectionField = function (_Component) {
                 onFocus: this.onSelectorFocus,
                 onQueryChange: this.onSelectorQueryChange,
                 optionComponent: Option,
+                optionControlComponent: OptionControl,
                 params: attributes.search_params,
                 perPage: attributes.search_per_page,
                 query: selectorQuery,
@@ -464,7 +470,7 @@ var SearchSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 276
+                  lineNumber: 282
                 },
                 __self: this
               })
@@ -472,7 +478,7 @@ var SearchSelectionField = function (_Component) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 294
+              lineNumber: 301
             },
             __self: this
           }) : null
@@ -513,6 +519,7 @@ SearchSelectionField.propTypes = {
     selector_label: PropTypes.string,
     selection: PropTypes.object,
     render_option_as: PropTypes.string,
+    render_option_control_as: PropTypes.string,
     render_selection_as: PropTypes.string
   }),
   hint: PropTypes.string,

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -171,6 +171,7 @@ var SearchSelector = function (_Component) {
       var _props3 = this.props,
           onSelection = _props3.onSelection,
           optionComponent = _props3.optionComponent,
+          optionControlComponent = _props3.optionControlComponent,
           selectedIds = _props3.selectedIds;
       var _state = this.state,
           hasSearched = _state.hasSearched,
@@ -215,11 +216,13 @@ var SearchSelector = function (_Component) {
 
       var resultClassNames = classNames(styles.results, _defineProperty({}, "" + styles.resultsLoading, loading));
 
+      var OptionControl = optionControlComponent;
+
       return React.createElement(
         "div",
         { "data-search-selector": true, className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 166
+            lineNumber: 168
           },
           __self: this
         },
@@ -237,13 +240,19 @@ var SearchSelector = function (_Component) {
           onChange: this.onSearchChange,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 167
+            lineNumber: 169
           },
           __self: this
         }),
         loading ? React.createElement(Spinner, { className: styles.spinner, __source: {
             fileName: _jsxFileName,
-            lineNumber: 180
+            lineNumber: 182
+          },
+          __self: this
+        }) : null,
+        OptionControl ? React.createElement(OptionControl, { hasQuery: hasQuery, options: options, onSelection: onSelection, __source: {
+            fileName: _jsxFileName,
+            lineNumber: 183
           },
           __self: this
         }) : null,
@@ -251,7 +260,7 @@ var SearchSelector = function (_Component) {
           "div",
           { "data-search-selector-results": true, className: resultClassNames, __source: {
               fileName: _jsxFileName,
-              lineNumber: 182
+              lineNumber: 185
             },
             __self: this
           },
@@ -259,7 +268,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.pagination, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 183
+                lineNumber: 186
               },
               __self: this
             },
@@ -269,7 +278,7 @@ var SearchSelector = function (_Component) {
               goToPage: this.goToPage,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 184
+                lineNumber: 187
               },
               __self: this
             })
@@ -278,7 +287,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.list, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 190
+                lineNumber: 193
               },
               __self: this
             },
@@ -288,7 +297,7 @@ var SearchSelector = function (_Component) {
           "p",
           { className: styles.noResults, __source: {
               fileName: _jsxFileName,
-              lineNumber: 193
+              lineNumber: 196
             },
             __self: this
           },
@@ -324,6 +333,7 @@ SearchSelector.propTypes = {
   onQueryChange: PropTypes.func,
   onSelection: PropTypes.func.isRequired,
   optionComponent: PropTypes.func,
+  optionControlComponent: PropTypes.func,
   selectedIds: PropTypes.array,
   params: PropTypes.object,
   perPage: PropTypes.number,
@@ -343,7 +353,7 @@ function OptionComponent(_ref) {
     {
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 233
+        lineNumber: 237
       },
       __self: this
     },

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -183,6 +183,9 @@ var SearchSelector = function (_Component) {
 
       var hasQuery = this.query != null && this.query !== "";
 
+      // OptionControl component
+      var OptionControl = optionControlComponent;
+
       // Render each option
       var Option = optionComponent;
       var options = results.map(function (option) {
@@ -201,13 +204,13 @@ var SearchSelector = function (_Component) {
             onClick: onClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 150
+              lineNumber: 153
             },
             __self: _this2
           },
           React.createElement(Option, { option: option, __source: {
               fileName: _jsxFileName,
-              lineNumber: 156
+              lineNumber: 159
             },
             __self: _this2
           })
@@ -216,13 +219,11 @@ var SearchSelector = function (_Component) {
 
       var resultClassNames = classNames(styles.results, _defineProperty({}, "" + styles.resultsLoading, loading));
 
-      var OptionControl = optionControlComponent;
-
       return React.createElement(
         "div",
         { "data-search-selector": true, className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 168
+            lineNumber: 169
           },
           __self: this
         },
@@ -240,19 +241,19 @@ var SearchSelector = function (_Component) {
           onChange: this.onSearchChange,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 169
+            lineNumber: 170
           },
           __self: this
         }),
         loading ? React.createElement(Spinner, { className: styles.spinner, __source: {
             fileName: _jsxFileName,
-            lineNumber: 182
+            lineNumber: 183
           },
           __self: this
         }) : null,
         OptionControl ? React.createElement(OptionControl, { hasQuery: hasQuery, options: options, onSelection: onSelection, __source: {
             fileName: _jsxFileName,
-            lineNumber: 183
+            lineNumber: 184
           },
           __self: this
         }) : null,
@@ -260,7 +261,7 @@ var SearchSelector = function (_Component) {
           "div",
           { "data-search-selector-results": true, className: resultClassNames, __source: {
               fileName: _jsxFileName,
-              lineNumber: 185
+              lineNumber: 186
             },
             __self: this
           },
@@ -268,7 +269,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.pagination, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 186
+                lineNumber: 187
               },
               __self: this
             },
@@ -278,7 +279,7 @@ var SearchSelector = function (_Component) {
               goToPage: this.goToPage,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 187
+                lineNumber: 188
               },
               __self: this
             })
@@ -287,7 +288,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.list, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 193
+                lineNumber: 194
               },
               __self: this
             },
@@ -297,7 +298,7 @@ var SearchSelector = function (_Component) {
           "p",
           { className: styles.noResults, __source: {
               fileName: _jsxFileName,
-              lineNumber: 196
+              lineNumber: 197
             },
             __self: this
           },
@@ -353,7 +354,7 @@ function OptionComponent(_ref) {
     {
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 237
+        lineNumber: 238
       },
       __self: this
     },

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -74,6 +74,7 @@ class SearchMultiSelectionField extends Component {
     this.onSelectorBlur = this.onSelectorBlur.bind(this);
     this.onSelectorFocus = this.onSelectorFocus.bind(this);
     this.onSelectorQueryChange = this.onSelectorQueryChange.bind(this);
+    this.fetchSelectionsData = this.fetchSelectionsData.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -86,7 +87,15 @@ class SearchMultiSelectionField extends Component {
    * @return {Null}
    */
   componentWillMount() {
-    // Do an XHR request for the additional selection data
+    this.fetchSelectionsData();
+  }
+
+  /**
+   * fetchSelectionsData
+   * Do an XHR request for the additional selections data
+   * @return {Null}
+   */
+  fetchSelectionsData() {
     const { attributes, value } = this.props;
     if (value && value.count() > 0) {
       const { search_url } = attributes;
@@ -325,7 +334,7 @@ class SearchMultiSelectionField extends Component {
           <div className={styles.selectedItems}>
             <Sortable canRemove onRemove={this.onRemove} onDrop={this.onDrop}>
               {selections.map((option, index) => (
-                <Selection key={`${index}_${option.id}`} option={option} />
+                <Selection key={`${index}_${option.id}`} option={option} fetchSelectionsData={this.fetchSelectionsData} />
               ))}
             </Sortable>
           </div>

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -247,7 +247,8 @@ class SearchMultiSelectionField extends Component {
       placeholder,
       selector_label,
       render_option_as,
-      render_selection_as
+      render_option_control_as,
+      render_selection_as,
     } = attributes;
     const { selections, selectorFocus, selectorQuery } = this.state;
     const hasErrors = errors.count() > 0;
@@ -259,6 +260,7 @@ class SearchMultiSelectionField extends Component {
 
     // Determine the selection/selected display components
     let Option = SelectDefault;
+    let OptionControl = null;
     let Selection = SelectDefault;
 
     // Extract them from the passed `config.components` if it exists
@@ -266,6 +268,10 @@ class SearchMultiSelectionField extends Component {
       if (render_option_as) {
         Option =
           extractComponent(config.components, render_option_as) || Option;
+      }
+      if (render_option_control_as) {
+        OptionControl =
+          extractComponent(config.components, render_option_control_as) || OptionControl;
       }
       if (render_selection_as) {
         Selection =
@@ -320,6 +326,7 @@ class SearchMultiSelectionField extends Component {
                 onFocus={this.onSelectorFocus}
                 onQueryChange={this.onSelectorQueryChange}
                 optionComponent={Option}
+                optionControlComponent={OptionControl}
                 params={attributes.search_params}
                 perPage={attributes.search_per_page}
                 query={selectorQuery}
@@ -371,6 +378,7 @@ SearchMultiSelectionField.propTypes = {
     search_threshold: PropTypes.number,
     selector_label: PropTypes.string,
     render_option_as: PropTypes.string,
+    render_option_control_as: PropTypes.string,
     render_selection_as: PropTypes.string
   }),
   hint: PropTypes.string,

--- a/src/components/fields/search-selection-field/index.js
+++ b/src/components/fields/search-selection-field/index.js
@@ -205,6 +205,7 @@ class SearchSelectionField extends Component {
       placeholder,
       selector_label,
       render_option_as,
+      render_option_control_as,
       render_selection_as
     } = attributes;
     const { selection, selectorFocus, selectorQuery } = this.state;
@@ -217,6 +218,7 @@ class SearchSelectionField extends Component {
 
     // Determine the selection/selected display components
     let Option = SelectDefault;
+    let OptionControl = null;
     let Selection = SelectDefault;
 
     // Extract them from the passed `config.components` if it exists
@@ -224,6 +226,10 @@ class SearchSelectionField extends Component {
       if (render_option_as) {
         Option =
           extractComponent(config.components, render_option_as) || Option;
+      }
+      if (render_option_control_as) {
+        OptionControl =
+          extractComponent(config.components, render_option_control_as) || OptionControl;
       }
       if (render_selection_as) {
         Selection =
@@ -282,6 +288,7 @@ class SearchSelectionField extends Component {
                   onFocus={this.onSelectorFocus}
                   onQueryChange={this.onSelectorQueryChange}
                   optionComponent={Option}
+                  optionControlComponent={OptionControl}
                   params={attributes.search_params}
                   perPage={attributes.search_per_page}
                   query={selectorQuery}
@@ -325,6 +332,7 @@ SearchSelectionField.propTypes = {
     selector_label: PropTypes.string,
     selection: PropTypes.object,
     render_option_as: PropTypes.string,
+    render_option_control_as: PropTypes.string,
     render_selection_as: PropTypes.string
   }),
   hint: PropTypes.string,

--- a/src/components/fields/search-selection-field/index.js
+++ b/src/components/fields/search-selection-field/index.js
@@ -63,6 +63,7 @@ class SearchSelectionField extends Component {
     this.onSelectorBlur = this.onSelectorBlur.bind(this);
     this.onSelectorFocus = this.onSelectorFocus.bind(this);
     this.onSelectorQueryChange = this.onSelectorQueryChange.bind(this);
+    this.fetchSelectionData = this.fetchSelectionData.bind(this);
   }
 
   /**
@@ -71,7 +72,15 @@ class SearchSelectionField extends Component {
    * @return {Null}
    */
   componentWillMount() {
-    // Do an XHR request for the additional selection data
+    this.fetchSelectionData();
+  }
+
+  /**
+   * fetchSelectionData
+   * Do an XHR request for the additional selection data
+   * @return {Null}
+   */
+  fetchSelectionData() {
     const { attributes, value } = this.props;
     if (value) {
       const { search_url } = attributes;
@@ -235,7 +244,7 @@ class SearchSelectionField extends Component {
           {selection ? (
             <div className={styles.wrapper}>
               <div className={styles.selection}>
-                <Selection option={selection} />
+                <Selection option={selection} fetchSelectionData={this.fetchSelectionData} />
               </div>
               <button className={styles.remove} onClick={this.onRemoveClick}>
                 <span className={styles.removeText}>Remove</span>

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -135,6 +135,9 @@ class SearchSelector extends Component {
     // Has query?
     const hasQuery = this.query != null && this.query !== "";
 
+    // OptionControl component
+    const OptionControl = optionControlComponent;
+
     // Render each option
     const Option = optionComponent;
     const options = results.map(option => {
@@ -161,8 +164,6 @@ class SearchSelector extends Component {
     const resultClassNames = classNames(styles.results, {
       [`${styles.resultsLoading}`]: loading
     });
-
-    const OptionControl = optionControlComponent;
 
     return (
       <div data-search-selector className={styles.base}>

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -129,7 +129,7 @@ class SearchSelector extends Component {
   }
 
   render() {
-    const { onSelection, optionComponent, selectedIds } = this.props;
+    const { onSelection, optionComponent, optionControlComponent, selectedIds } = this.props;
     const { hasSearched, loading, results, pagination } = this.state;
 
     // Has query?
@@ -162,6 +162,8 @@ class SearchSelector extends Component {
       [`${styles.resultsLoading}`]: loading
     });
 
+    const OptionControl = optionControlComponent;
+
     return (
       <div data-search-selector className={styles.base}>
         <input
@@ -178,6 +180,7 @@ class SearchSelector extends Component {
           onChange={this.onSearchChange}
         />
         {loading ? <Spinner className={styles.spinner} /> : null}
+        {OptionControl ? <OptionControl hasQuery={hasQuery} options={options} onSelection={onSelection} /> : null}
         {options.length > 0 ? (
           <div data-search-selector-results className={resultClassNames}>
             <div className={styles.pagination}>
@@ -218,6 +221,7 @@ SearchSelector.propTypes = {
   onQueryChange: PropTypes.func,
   onSelection: PropTypes.func.isRequired,
   optionComponent: PropTypes.func,
+  optionControlComponent: PropTypes.func,
   selectedIds: PropTypes.array,
   params: PropTypes.object,
   perPage: PropTypes.number,


### PR DESCRIPTION
This adds support for specifying custom option controls on search selection fields. Fetching of selection(s) data is also refactored into a function, that can then be supplied to child Selections for later use. 

An example usage of both features can be seen in: https://github.com/icelab/rrr/pull/285

One question I have @makenosound is around whether these two pieces of code are the right way to handle optionally supplying a component to be rendered:

```
let OptionControl = null;
```

```
{OptionControl ? <OptionControl hasQuery={hasQuery} options={options} onSelection={onSelection} /> : null}
```