### PR TITLE
Fix cursor lag/double change by removing React render cycle

### DIFF
--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
@@ -2,8 +2,6 @@ var _jsxFileName = "src/components/ui/rich-text-editor/block-toolbar-plugin/bloc
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -55,15 +53,12 @@ var AtomicBlock = function (_React$Component) {
           editorEmitter.emit("atomic:selected", blockKey);
         }
       }
-      _this.setState({
-        isSelected: isSelected
-      });
+      _this.isSelected = isSelected;
+      _this.manuallySetSelectedClass();
     };
 
     _this.onFocus = function (e) {
-      _this.setState({
-        isSelected: false
-      });
+      _this.isSelected = false;
       _this.setReadOnly(true);
     };
 
@@ -92,9 +87,7 @@ var AtomicBlock = function (_React$Component) {
     // Set a per instance ID for talking to the bus
     _this.instanceId = uid();
 
-    _this.state = {
-      isSelected: false
-    };
+    _this.isSelected = false;
     return _this;
   }
 
@@ -168,16 +161,46 @@ var AtomicBlock = function (_React$Component) {
       editorEmitter.off("blur", this.checkEditorSelection);
     }
   }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate() {
+      this.manuallySetSelectedClass();
+    }
+
+    /*
+     * NOTE: This function *must* manually set the className for the selected for
+     * not-quite-known reasons. There appears to be a timing issue in the editor
+     * that results in multiple but slightly out of sync changes being called
+     * when:
+     *
+     * - A formalist atomic block is rendered that has a state change in its
+     *   component
+     * - User presses enter to create a new block
+     * - User presses up
+     *
+     * The problem goes away when the exported editor state isn’t passed back to
+     * the formalist AST, which makes it _seem_ like it’s tied to rendering but
+     * the `editorState` object doesn’t get re-interpreted and so that seems odd.
+     * At a guess, it’s a timing issue releated to setState being async and so
+     * when the AST is updated and the component is rerendered it renders twice in
+     * the same moment: one with the new state and the with the old state.
+     */
+
+  }, {
+    key: "manuallySetSelectedClass",
+    value: function manuallySetSelectedClass() {
+      if (this._blockContainer) {
+        this.isSelected ? this._blockContainer.classList.add(styles.containerSelected) : this._blockContainer.classList.remove(styles.containerSelected);
+      }
+    }
+  }, {
     key: "render",
     value: function render() {
       var _this3 = this;
 
-      var isSelected = this.state.isSelected;
-
       var _entity$getData = this.entity.getData(),
           label = _entity$getData.label;
 
-      var containerClassNames = classNames(styles.container, _defineProperty({}, "" + styles.containerSelected, isSelected));
+      var containerClassNames = classNames(styles.container);
 
       // TODO Assess whether to remove this binding
       /* eslint-disable react/jsx-no-bind */
@@ -189,7 +212,7 @@ var AtomicBlock = function (_React$Component) {
           "data-debug-block-key": this.props.block.getKey(),
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 166
+            lineNumber: 188
           },
           __self: this
         },
@@ -197,14 +220,14 @@ var AtomicBlock = function (_React$Component) {
           "div",
           { className: styles.caret, __source: {
               fileName: _jsxFileName,
-              lineNumber: 171
+              lineNumber: 193
             },
             __self: this
           },
           React.createElement("br", {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 172
+              lineNumber: 194
             },
             __self: this
           })
@@ -222,7 +245,7 @@ var AtomicBlock = function (_React$Component) {
             contentEditable: false,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 174
+              lineNumber: 196
             },
             __self: this
           },
@@ -230,7 +253,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.header, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 184
+                lineNumber: 206
               },
               __self: this
             },
@@ -238,7 +261,7 @@ var AtomicBlock = function (_React$Component) {
               "h3",
               { className: styles.label, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 185
+                  lineNumber: 207
                 },
                 __self: this
               },
@@ -248,7 +271,7 @@ var AtomicBlock = function (_React$Component) {
               "div",
               { className: styles.toolbar, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 186
+                  lineNumber: 208
                 },
                 __self: this
               },
@@ -263,7 +286,7 @@ var AtomicBlock = function (_React$Component) {
                   },
                   __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 187
+                    lineNumber: 209
                   },
                   __self: this
                 },
@@ -271,7 +294,7 @@ var AtomicBlock = function (_React$Component) {
                   "span",
                   { className: styles.removeText, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 195
+                      lineNumber: 217
                     },
                     __self: this
                   },
@@ -281,7 +304,7 @@ var AtomicBlock = function (_React$Component) {
                   "div",
                   { className: styles.removeX, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 196
+                      lineNumber: 218
                     },
                     __self: this
                   },
@@ -294,7 +317,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.content, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 200
+                lineNumber: 222
               },
               __self: this
             },

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -15,7 +15,6 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import PluginsEditor from "draft-js-plugins-editor";
 import Emitter from "component-emitter";
-import debounce from "lodash.debounce";
 import { belongsToAtomicBlockOrPortal } from "./utils";
 import capitalize from "../../../utils/capitalize";
 
@@ -116,16 +115,10 @@ var RichTextEditor = function (_React$Component) {
       }
     }, _this.onChange = function (editorState) {
       var onChange = _this.props.onChange;
-
-      _this.emitter.emit("change", editorState);
       // eslint-disable-next-line no-unused-expressions
+
       onChange(editorState);
-      // Replace this function with a debounced version of itself after the
-      // first invocation. Yes this is silly.
-      if (!_this.onChangeDebounced) {
-        _this.onChangeDebounced = true;
-        _this.onChange = debounce(_this.onChange, 1);
-      }
+      _this.emitter.emit("change", editorState);
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
@@ -174,21 +167,6 @@ var RichTextEditor = function (_React$Component) {
 
     /**
      * onChange
-     * NOTE: This function *must* be debounced for not-quite-known reasons. There
-     * appears to be a timing issue in the editor that results in multiple but
-     * slightly out of sync changes being called when:
-     *
-     * - A formalist atomic block is rendered that has a state change in its
-     *   component, e.g., atomic/index.js -> setState({isSelected})
-     * - User presses enter to create a new block
-     * - User presses up
-     *
-     * The problem goes away when the exported editor state isn’t passed back
-     * to the formalist AST, which makes it _seem_ like it’s tied to rendering
-     * but the `editorState` object doesn’t get re-interpreted and so that seems
-     * odd. At a guess, it’s a timing issue releated to setState being async and
-     * so when the AST is updated and the component is rerendered it renders twice
-     * in the same moment: one with the new state and the with the old state.
      */
 
   }, {
@@ -224,7 +202,7 @@ var RichTextEditor = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 215
+            lineNumber: 193
           },
           __self: this
         },
@@ -232,7 +210,7 @@ var RichTextEditor = function (_React$Component) {
           "div",
           { className: styles.gutter, __source: {
               fileName: _jsxFileName,
-              lineNumber: 217
+              lineNumber: 195
             },
             __self: this
           },
@@ -243,7 +221,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 218
+              lineNumber: 196
             },
             __self: this
           })
@@ -258,7 +236,7 @@ var RichTextEditor = function (_React$Component) {
             onClick: this.onContentClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 226
+              lineNumber: 204
             },
             __self: this
           },
@@ -268,7 +246,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 233
+              lineNumber: 211
             },
             __self: this
           }),
@@ -287,7 +265,7 @@ var RichTextEditor = function (_React$Component) {
             webDriverTestID: webDriverTestID,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 238
+              lineNumber: 216
             },
             __self: this
           })

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import PluginsEditor from "draft-js-plugins-editor";
 import Emitter from "component-emitter";
-import debounce from "lodash.debounce";
 import { belongsToAtomicBlockOrPortal } from "./utils";
 import capitalize from "../../../utils/capitalize";
 
@@ -153,33 +152,12 @@ class RichTextEditor extends React.Component {
 
   /**
    * onChange
-   * NOTE: This function *must* be debounced for not-quite-known reasons. There
-   * appears to be a timing issue in the editor that results in multiple but
-   * slightly out of sync changes being called when:
-   *
-   * - A formalist atomic block is rendered that has a state change in its
-   *   component, e.g., atomic/index.js -> setState({isSelected})
-   * - User presses enter to create a new block
-   * - User presses up
-   *
-   * The problem goes away when the exported editor state isn’t passed back
-   * to the formalist AST, which makes it _seem_ like it’s tied to rendering
-   * but the `editorState` object doesn’t get re-interpreted and so that seems
-   * odd. At a guess, it’s a timing issue releated to setState being async and
-   * so when the AST is updated and the component is rerendered it renders twice
-   * in the same moment: one with the new state and the with the old state.
    */
   onChange = editorState => {
     const { onChange } = this.props;
-    this.emitter.emit("change", editorState);
     // eslint-disable-next-line no-unused-expressions
     onChange(editorState);
-    // Replace this function with a debounced version of itself after the
-    // first invocation. Yes this is silly.
-    if (!this.onChangeDebounced) {
-      this.onChangeDebounced = true;
-      this.onChange = debounce(this.onChange, 1);
-    }
+    this.emitter.emit("change", editorState);
   };
 
   render() {


### PR DESCRIPTION
Reverts the change in https://github.com/icelab/formalist-standard-react/pull/146 and replaces it instead with a *manual* `className` change rather than a stateful render.