### PR TITLE
Improve performance of Rich Text Editor

### DIFF
--- a/lib/components/fields/rich-text-area/index.js
+++ b/lib/components/fields/rich-text-area/index.js
@@ -88,7 +88,7 @@ var RichTextArea = function (_React$Component) {
           "data-field-type": "rich-text-area",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 116
+            lineNumber: 127
           },
           __self: this
         },
@@ -96,13 +96,13 @@ var RichTextArea = function (_React$Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 121
+              lineNumber: 132
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 122
+              lineNumber: 133
             },
             __self: this
           })
@@ -111,7 +111,7 @@ var RichTextArea = function (_React$Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 124
+              lineNumber: 135
             },
             __self: this
           },
@@ -129,13 +129,13 @@ var RichTextArea = function (_React$Component) {
             fieldBus: bus,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 125
+              lineNumber: 136
             },
             __self: this
           }),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 138
+              lineNumber: 149
             },
             __self: this
           }) : null
@@ -171,36 +171,44 @@ RichTextArea.propTypes = {
 var _initialiseProps = function _initialiseProps() {
   var _this2 = this;
 
-  this.onChange = function (editorState) {
-    var value = _this2.props.value;
+  this.onChange = function (editorState, _ref) {
+    var _ref$forceChange = _ref.forceChange,
+        forceChange = _ref$forceChange === undefined ? false : _ref$forceChange;
 
-    var exporterOptions = {
-      entityModifiers: {
-        formalist: function formalist(data) {
-          var copy = Object.assign({}, data);
-          delete copy["label"];
-          delete copy["form"];
-          return copy;
+    if (forceChange || editorState !== _this2.state.editorState) {
+      // Check if contentState has changed
+      if (forceChange || editorState.getCurrentContent() !== _this2.state.editorState.getCurrentContent()) {
+        var value = _this2.props.value;
+
+        var exporterOptions = {
+          entityModifiers: {
+            formalist: function formalist(data) {
+              var copy = Object.assign({}, data);
+              delete copy["label"];
+              delete copy["form"];
+              return copy;
+            }
+          }
+        };
+        var currentContent = editorState.getCurrentContent();
+        var hasText = currentContent.hasText();
+        var newValue = hasText ? exporter(editorState, exporterOptions) : null;
+        var hasChangedToNull = newValue === null && value !== null;
+
+        // Persist the value to the AST, but only if it is:
+        // * Not null
+        // * Has changed to null
+        if (newValue != null || hasChangedToNull) {
+          _this2.props.actions.edit(function (val) {
+            return newValue;
+          });
         }
       }
-    };
-    var currentContent = editorState.getCurrentContent();
-    var hasText = currentContent.hasText();
-    var newValue = hasText ? exporter(editorState, exporterOptions) : null;
-    var hasChangedToNull = newValue === null && value !== null;
-
-    // Persist the value to the AST, but only if it is:
-    // * Not null
-    // * Has changed to null
-    if (newValue != null || hasChangedToNull) {
-      _this2.props.actions.edit(function (val) {
-        return newValue;
+      // Keep track of the state here
+      _this2.setState({
+        editorState: editorState
       });
     }
-    // Keep track of the state here
-    _this2.setState({
-      editorState: editorState
-    });
   };
 };
 

--- a/lib/components/fields/rich-text-area/index.js
+++ b/lib/components/fields/rich-text-area/index.js
@@ -15,6 +15,7 @@ import PropTypes from "prop-types";
 import ImmutablePropTypes from "react-immutable-proptypes";
 import classNames from "classnames";
 import { EditorState } from "draft-js";
+import debounce from "lodash.debounce";
 
 // Import components
 import FieldErrors from "../common/errors";
@@ -56,6 +57,14 @@ var RichTextArea = function (_React$Component) {
   }
 
   /**
+   * Persist data
+   *
+   * This is debounced slightly to avoid thrashing the AST when changes are
+   * occuring in rapid succession
+   */
+
+
+  /**
    * onChange handler
    *
    * @param  {EditorState} editorState State from the editor
@@ -88,7 +97,7 @@ var RichTextArea = function (_React$Component) {
           "data-field-type": "rich-text-area",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 127
+            lineNumber: 136
           },
           __self: this
         },
@@ -96,13 +105,13 @@ var RichTextArea = function (_React$Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 132
+              lineNumber: 141
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 133
+              lineNumber: 142
             },
             __self: this
           })
@@ -111,7 +120,7 @@ var RichTextArea = function (_React$Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 135
+              lineNumber: 144
             },
             __self: this
           },
@@ -129,13 +138,13 @@ var RichTextArea = function (_React$Component) {
             fieldBus: bus,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 136
+              lineNumber: 145
             },
             __self: this
           }),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 149
+              lineNumber: 158
             },
             __self: this
           }) : null
@@ -171,38 +180,41 @@ RichTextArea.propTypes = {
 var _initialiseProps = function _initialiseProps() {
   var _this2 = this;
 
-  this.onChange = function (editorState, _ref) {
-    var _ref$forceChange = _ref.forceChange,
-        forceChange = _ref$forceChange === undefined ? false : _ref$forceChange;
+  this.persistData = debounce(function (editorState) {
+    var value = _this2.props.value;
+
+    var exporterOptions = {
+      entityModifiers: {
+        formalist: function formalist(data) {
+          var copy = Object.assign({}, data);
+          delete copy["label"];
+          delete copy["form"];
+          return copy;
+        }
+      }
+    };
+    var currentContent = editorState.getCurrentContent();
+    var hasText = currentContent.hasText();
+    var newValue = hasText ? exporter(editorState, exporterOptions) : null;
+    var hasChangedToNull = newValue === null && value !== null;
+
+    // Persist the value to the AST, but only if it is:
+    // * Not null
+    // * Has changed to null
+    if (newValue != null || hasChangedToNull) {
+      _this2.props.actions.edit(function (val) {
+        return newValue;
+      });
+    }
+  }, 10);
+
+  this.onChange = function (editorState) {
+    var forceChange = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
     if (forceChange || editorState !== _this2.state.editorState) {
       // Check if contentState has changed
       if (forceChange || editorState.getCurrentContent() !== _this2.state.editorState.getCurrentContent()) {
-        var value = _this2.props.value;
-
-        var exporterOptions = {
-          entityModifiers: {
-            formalist: function formalist(data) {
-              var copy = Object.assign({}, data);
-              delete copy["label"];
-              delete copy["form"];
-              return copy;
-            }
-          }
-        };
-        var currentContent = editorState.getCurrentContent();
-        var hasText = currentContent.hasText();
-        var newValue = hasText ? exporter(editorState, exporterOptions) : null;
-        var hasChangedToNull = newValue === null && value !== null;
-
-        // Persist the value to the AST, but only if it is:
-        // * Not null
-        // * Has changed to null
-        if (newValue != null || hasChangedToNull) {
-          _this2.props.actions.edit(function (val) {
-            return newValue;
-          });
-        }
+        _this2.persistData(editorState);
       }
       // Keep track of the state here
       _this2.setState({

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -113,15 +113,14 @@ var RichTextEditor = function (_React$Component) {
       if (e.target === _this.contentEl) {
         _this._editor.focus();
       }
-    }, _this.onChange = function (editorState, _ref2) {
-      var _ref2$forceChange = _ref2.forceChange,
-          forceChange = _ref2$forceChange === undefined ? false : _ref2$forceChange;
+    }, _this.onChange = function (editorState) {
+      var forceChange = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
       if (forceChange || editorState !== _this.props.editorState) {
         var onChange = _this.props.onChange;
         // eslint-disable-next-line no-unused-expressions
 
-        onChange(editorState, { forceChange: forceChange });
+        onChange(editorState, forceChange);
         _this.emitter.emit("change", editorState);
       }
     }, _temp), _possibleConstructorReturn(_this, _ret);
@@ -143,7 +142,8 @@ var RichTextEditor = function (_React$Component) {
       this.emitter.on("atomic:change", function () {
         var editorState = _this2.props.editorState;
 
-        _this2.onChange(editorState, { forceChange: true });
+        var forceChange = true;
+        _this2.onChange(editorState, forceChange);
       });
 
       var plugins = this.configurePlugins();
@@ -207,7 +207,7 @@ var RichTextEditor = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 195
+            lineNumber: 196
           },
           __self: this
         },
@@ -215,7 +215,7 @@ var RichTextEditor = function (_React$Component) {
           "div",
           { className: styles.gutter, __source: {
               fileName: _jsxFileName,
-              lineNumber: 197
+              lineNumber: 198
             },
             __self: this
           },
@@ -226,7 +226,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 198
+              lineNumber: 199
             },
             __self: this
           })
@@ -241,7 +241,7 @@ var RichTextEditor = function (_React$Component) {
             onClick: this.onContentClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 206
+              lineNumber: 207
             },
             __self: this
           },
@@ -251,7 +251,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 213
+              lineNumber: 214
             },
             __self: this
           }),
@@ -270,7 +270,7 @@ var RichTextEditor = function (_React$Component) {
             webDriverTestID: webDriverTestID,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 218
+              lineNumber: 219
             },
             __self: this
           })

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -116,6 +116,7 @@ var RichTextEditor = function (_React$Component) {
     }, _this.onChange = function (editorState) {
       var forceChange = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
+      forceChange = forceChange === true ? true : false;
       if (forceChange || editorState !== _this.props.editorState) {
         var onChange = _this.props.onChange;
         // eslint-disable-next-line no-unused-expressions
@@ -207,7 +208,7 @@ var RichTextEditor = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 196
+            lineNumber: 197
           },
           __self: this
         },
@@ -215,7 +216,7 @@ var RichTextEditor = function (_React$Component) {
           "div",
           { className: styles.gutter, __source: {
               fileName: _jsxFileName,
-              lineNumber: 198
+              lineNumber: 199
             },
             __self: this
           },
@@ -226,7 +227,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 199
+              lineNumber: 200
             },
             __self: this
           })
@@ -241,7 +242,7 @@ var RichTextEditor = function (_React$Component) {
             onClick: this.onContentClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 207
+              lineNumber: 208
             },
             __self: this
           },
@@ -251,7 +252,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 214
+              lineNumber: 215
             },
             __self: this
           }),
@@ -270,7 +271,7 @@ var RichTextEditor = function (_React$Component) {
             webDriverTestID: webDriverTestID,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 219
+              lineNumber: 220
             },
             __self: this
           })

--- a/lib/components/ui/rich-text-editor/index.js
+++ b/lib/components/ui/rich-text-editor/index.js
@@ -113,12 +113,17 @@ var RichTextEditor = function (_React$Component) {
       if (e.target === _this.contentEl) {
         _this._editor.focus();
       }
-    }, _this.onChange = function (editorState) {
-      var onChange = _this.props.onChange;
-      // eslint-disable-next-line no-unused-expressions
+    }, _this.onChange = function (editorState, _ref2) {
+      var _ref2$forceChange = _ref2.forceChange,
+          forceChange = _ref2$forceChange === undefined ? false : _ref2$forceChange;
 
-      onChange(editorState);
-      _this.emitter.emit("change", editorState);
+      if (forceChange || editorState !== _this.props.editorState) {
+        var onChange = _this.props.onChange;
+        // eslint-disable-next-line no-unused-expressions
+
+        onChange(editorState, { forceChange: forceChange });
+        _this.emitter.emit("change", editorState);
+      }
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
@@ -138,7 +143,7 @@ var RichTextEditor = function (_React$Component) {
       this.emitter.on("atomic:change", function () {
         var editorState = _this2.props.editorState;
 
-        _this2.onChange(editorState);
+        _this2.onChange(editorState, { forceChange: true });
       });
 
       var plugins = this.configurePlugins();
@@ -202,7 +207,7 @@ var RichTextEditor = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 193
+            lineNumber: 195
           },
           __self: this
         },
@@ -210,7 +215,7 @@ var RichTextEditor = function (_React$Component) {
           "div",
           { className: styles.gutter, __source: {
               fileName: _jsxFileName,
-              lineNumber: 195
+              lineNumber: 197
             },
             __self: this
           },
@@ -221,7 +226,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 196
+              lineNumber: 198
             },
             __self: this
           })
@@ -236,7 +241,7 @@ var RichTextEditor = function (_React$Component) {
             onClick: this.onContentClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 204
+              lineNumber: 206
             },
             __self: this
           },
@@ -246,7 +251,7 @@ var RichTextEditor = function (_React$Component) {
             onChange: this.onChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 211
+              lineNumber: 213
             },
             __self: this
           }),
@@ -265,7 +270,7 @@ var RichTextEditor = function (_React$Component) {
             webDriverTestID: webDriverTestID,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 216
+              lineNumber: 218
             },
             __self: this
           })

--- a/src/components/fields/rich-text-area/index.js
+++ b/src/components/fields/rich-text-area/index.js
@@ -71,7 +71,7 @@ class RichTextArea extends React.Component {
    *
    * @param  {EditorState} editorState State from the editor
    */
-  onChange = (editorState, { forceChange = false }) => {
+  onChange = (editorState, forceChange = false) => {
     if (forceChange || editorState !== this.state.editorState) {
       // Check if contentState has changed
       if (

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -155,6 +155,7 @@ class RichTextEditor extends React.Component {
    * onChange
    */
   onChange = (editorState, forceChange = false) => {
+    forceChange = forceChange === true ? true : false;
     if (forceChange || editorState !== this.props.editorState) {
       const { onChange } = this.props;
       // eslint-disable-next-line no-unused-expressions

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -54,7 +54,7 @@ class RichTextEditor extends React.Component {
     // of the current data to get things to propagate around _immediately_.
     this.emitter.on("atomic:change", () => {
       const { editorState } = this.props;
-      this.onChange(editorState);
+      this.onChange(editorState, { forceChange: true });
     });
 
     const plugins = this.configurePlugins();
@@ -153,11 +153,13 @@ class RichTextEditor extends React.Component {
   /**
    * onChange
    */
-  onChange = editorState => {
-    const { onChange } = this.props;
-    // eslint-disable-next-line no-unused-expressions
-    onChange(editorState);
-    this.emitter.emit("change", editorState);
+  onChange = (editorState, { forceChange = false }) => {
+    if (forceChange || editorState !== this.props.editorState) {
+      const { onChange } = this.props;
+      // eslint-disable-next-line no-unused-expressions
+      onChange(editorState, { forceChange });
+      this.emitter.emit("change", editorState);
+    }
   };
 
   render() {

--- a/src/components/ui/rich-text-editor/index.js
+++ b/src/components/ui/rich-text-editor/index.js
@@ -54,7 +54,8 @@ class RichTextEditor extends React.Component {
     // of the current data to get things to propagate around _immediately_.
     this.emitter.on("atomic:change", () => {
       const { editorState } = this.props;
-      this.onChange(editorState, { forceChange: true });
+      const forceChange = true;
+      this.onChange(editorState, forceChange);
     });
 
     const plugins = this.configurePlugins();
@@ -153,11 +154,11 @@ class RichTextEditor extends React.Component {
   /**
    * onChange
    */
-  onChange = (editorState, { forceChange = false }) => {
+  onChange = (editorState, forceChange = false) => {
     if (forceChange || editorState !== this.props.editorState) {
       const { onChange } = this.props;
       // eslint-disable-next-line no-unused-expressions
-      onChange(editorState, { forceChange });
+      onChange(editorState, forceChange);
       this.emitter.emit("change", editorState);
     }
   };


### PR DESCRIPTION
We do this by:

* Only calling `onChange` when the `editorState` value itself has actually changed. There were cases when it would be called with the same value.
* Check if the `contentState` is different (as distinct from the `editorState`) and only update AST when it is
* Debounce that AST update a tiny bit so we don’t thrash as much if you’re trying really fast

Those checks fail when entity data is changed (because it’s still outside the content state object in draft-js v0.10.5), so we also have a manual override when we _know_ it should be reevaluated and updated in the AST (like when you’ve edited the value in an embedded form).