### PR TITLE
Bug/duplicated atomic blocks

### DIFF
--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/index.js
@@ -41,7 +41,9 @@ function getNextBlockTypeToApply(currentType, types) {
  * @param  {Array} editableBlockTypes List of editable types
  * @return {EditorState} Modified EditorState
  */
-function insertBlockAfterCurrentBlock(editorState, blockType, editableBlockTypes) {
+export function insertBlockAfterCurrentBlock(editorState, blockType, editableBlockTypes) {
+  var selectInsertedBlock = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+
   var selection = editorState.getSelection();
   var contentState = editorState.getCurrentContent();
   var currentBlock = contentState.getBlockForKey(selection.getEndKey());
@@ -56,7 +58,7 @@ function insertBlockAfterCurrentBlock(editorState, blockType, editableBlockTypes
   }).rest();
 
   var newBlockKey = genKey();
-  var emptyBlockKey = genKey();
+  var selectedBlockKey = newBlockKey;
   var newBlocks = [[currentBlock.getKey(), currentBlock], [newBlockKey, new ContentBlock({
     key: newBlockKey,
     type: blockType,
@@ -70,6 +72,8 @@ function insertBlockAfterCurrentBlock(editorState, blockType, editableBlockTypes
   var nextBlockIsEditable = nextBlock && editableBlockTypes.indexOf(nextBlock.getType()) > -1;
   var isLastBlock = currentBlock === contentState.getLastBlock();
   if (!nextBlockIsEditable || isLastBlock) {
+    var emptyBlockKey = genKey();
+    selectedBlockKey = emptyBlockKey;
     newBlocks = newBlocks.concat([[emptyBlockKey, new ContentBlock({
       key: emptyBlockKey,
       type: "unstyled",
@@ -79,10 +83,22 @@ function insertBlockAfterCurrentBlock(editorState, blockType, editableBlockTypes
   }
 
   var newBlockMap = blocksBefore.concat(newBlocks, blocksAfter).toOrderedMap();
+
+  var selectionAfter = selection;
+  if (selectInsertedBlock === true) {
+    // Set selection to start of empty block
+    selectionAfter = selectionAfter.merge({
+      anchorKey: selectedBlockKey,
+      anchorOffset: 0,
+      focusKey: selectedBlockKey,
+      focusOffset: 0,
+      isBackward: false
+    });
+  }
   var newContentState = contentState.merge({
     blockMap: newBlockMap,
     selectionBefore: selection,
-    selectionAfter: selection
+    selectionAfter: selectionAfter
   });
   return EditorState.push(editorState, newContentState, "insert-fragment");
 }
@@ -145,7 +161,7 @@ var BlockItems = function (_React$Component) {
             },
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 150
+              lineNumber: 165
             },
             __self: _this2
           },
@@ -155,7 +171,7 @@ var BlockItems = function (_React$Component) {
             dangerouslySetInnerHTML: { __html: displayItem.icon },
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 163
+              lineNumber: 178
             },
             __self: _this2
           }) : displayItem.label
@@ -179,7 +195,7 @@ var BlockItems = function (_React$Component) {
         "div",
         { className: styles.container, __source: {
             fileName: _jsxFileName,
-            lineNumber: 185
+            lineNumber: 200
           },
           __self: this
         },
@@ -189,7 +205,7 @@ var BlockItems = function (_React$Component) {
               return e.preventDefault();
             }, __source: {
               fileName: _jsxFileName,
-              lineNumber: 186
+              lineNumber: 201
             },
             __self: this
           },

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -2,6 +2,7 @@ var _jsxFileName = "src/components/ui/rich-text-editor/block-toolbar-plugin/inde
 import React from "react";
 import { DefaultDraftBlockRenderMap, EditorState } from "draft-js";
 import mergeDefaults from "../../../../utils/merge-defaults";
+import { insertBlockAfterCurrentBlock } from "./block-items";
 
 // Components
 import Toolbar from "./toolbar";
@@ -133,10 +134,10 @@ export default function blockToolbarPlugin() {
   var editableBlockTypes = getEditableBlockTypesFromGroups(blockItemsGroups);
 
   // Keep track of when an atomic block is selected
-  editorEmitter.on('change', function (key) {
+  editorEmitter.on("change", function (key) {
     selectedAtomicBlockKey = null;
   });
-  editorEmitter.on('atomic:selected', function (key) {
+  editorEmitter.on("atomic:selected", function (key) {
     selectedAtomicBlockKey = key;
   });
 
@@ -186,12 +187,23 @@ export default function blockToolbarPlugin() {
           return commands.DELETE_BLOCK;
         } else if (e.keyCode === 8) {
           return commands.BACKSPACE_BLOCK;
-        } else {
+        } else if (e.keyCode === 13) {
+          // Special handling for when the enter key is pressed while an
+          // atomic block is selected. This appears to be a draft-js bug. When
+          // this situation occurs the atomic block duplicated (though its
+          // entity does not). There's no way to do this so we just have to
+          // *immediately* reverse its function
           var editorState = getEditorState();
-          // Move the selection to the block below so that the content pla
-          var selection = editorState.getSelection();
-          var contentState = editorState.getCurrentContent();
-          var nextBlockKey = getNextBlockKey(selectedAtomicBlockKey, editorState);
+          window.requestAnimationFrame(function () {
+            setEditorState(insertBlockAfterCurrentBlock(editorState, "unstyled", editableBlockTypes, true));
+          });
+        } else {
+          var _editorState = getEditorState();
+          // Move the selection to the block below so that the content comes
+          // through there instead
+          var selection = _editorState.getSelection();
+          var contentState = _editorState.getCurrentContent();
+          var nextBlockKey = getNextBlockKey(selectedAtomicBlockKey, _editorState);
           contentState = contentState.merge({
             selectionBefore: selection,
             selectionAfter: selection.merge({
@@ -199,14 +211,14 @@ export default function blockToolbarPlugin() {
               focusKey: nextBlockKey
             })
           });
-          setEditorState(EditorState.push(editorState, contentState));
+          setEditorState(EditorState.push(_editorState, contentState));
         }
       } else if (e.keyCode === 8) {
-        var _editorState = getEditorState();
+        var _editorState2 = getEditorState();
         // Handle case where BACKSPACE before an uneditable block results in
         // screwed up selections
-        var _selection = _editorState.getSelection();
-        var _contentState = _editorState.getCurrentContent();
+        var _selection = _editorState2.getSelection();
+        var _contentState = _editorState2.getCurrentContent();
         var atStartOfBlock = _selection.isCollapsed() && _selection.getEndOffset() === 0;
         // Are we at the start of the current block?
         if (atStartOfBlock) {
@@ -222,39 +234,14 @@ export default function blockToolbarPlugin() {
 
 
     /**
-     * Handle return when atomic blocks are selected
-     */
-    handleReturn: function handleReturn(e, editorState, _ref3) {
-      var setEditorState = _ref3.setEditorState;
-
-      if (selectedAtomicBlockKey !== null) {
-        // Move the selection to the block below so that the content pla
-        var selection = editorState.getSelection();
-        var contentState = editorState.getCurrentContent();
-        var nextBlockKey = getNextBlockKey(selectedAtomicBlockKey, editorState);
-        contentState = contentState.merge({
-          selectionBefore: selection,
-          selectionAfter: selection.merge({
-            anchorKey: nextBlockKey,
-            focusKey: nextBlockKey
-          })
-        });
-        setEditorState(EditorState.push(editorState, contentState));
-        return true;
-      }
-      return false;
-    },
-
-
-    /**
      * Handle our custom command
      * @param  {String} command
      * @param  {EditorState} editorState The current editorState
      * @param  {Function} options.setEditorState
      * @return {Boolean} Did we handle it?
      */
-    handleKeyCommand: function handleKeyCommand(command, editorState, _ref4) {
-      var setEditorState = _ref4.setEditorState;
+    handleKeyCommand: function handleKeyCommand(command, editorState, _ref3) {
+      var setEditorState = _ref3.setEditorState;
 
       // Handle deletion of atomic blocks using our custom commands
       if (command === commands.DELETE_BLOCK) {
@@ -326,7 +313,7 @@ export default function blockToolbarPlugin() {
       return React.createElement(Toolbar, Object.assign({}, props, {
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 360
+          lineNumber: 354
         },
         __self: _this
       }));

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -235,31 +235,6 @@ export default function blockToolbarPlugin(options = {}) {
     },
 
     /**
-     * Handle return when atomic blocks are selected
-     */
-    handleReturn(e, editorState, { setEditorState }) {
-      if (selectedAtomicBlockKey !== null) {
-        // Move the selection to the block below so that the content pla
-        const selection = editorState.getSelection();
-        let contentState = editorState.getCurrentContent();
-        const nextBlockKey = getNextBlockKey(
-          selectedAtomicBlockKey,
-          editorState
-        );
-        contentState = contentState.merge({
-          selectionBefore: selection,
-          selectionAfter: selection.merge({
-            anchorKey: nextBlockKey,
-            focusKey: nextBlockKey
-          })
-        });
-        setEditorState(EditorState.push(editorState, contentState));
-        return true;
-      }
-      return false;
-    },
-
-    /**
      * Handle our custom command
      * @param  {String} command
      * @param  {EditorState} editorState The current editorState

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -144,12 +144,12 @@ export default function blockToolbarPlugin(options = {}) {
   const editableBlockTypes = getEditableBlockTypesFromGroups(blockItemsGroups);
 
   // Keep track of when an atomic block is selected
-  editorEmitter.on('change', (key) => {
-    selectedAtomicBlockKey = null
-  })
-  editorEmitter.on('atomic:selected', (key) => {
-    selectedAtomicBlockKey = key
-  })
+  editorEmitter.on("change", key => {
+    selectedAtomicBlockKey = null;
+  });
+  editorEmitter.on("atomic:selected", key => {
+    selectedAtomicBlockKey = key;
+  });
 
   return {
     /**

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { DefaultDraftBlockRenderMap, EditorState } from "draft-js";
 import mergeDefaults from "../../../../utils/merge-defaults";
+import { insertBlockAfterCurrentBlock } from "./block-items";
 
 // Components
 import Toolbar from "./toolbar";
@@ -193,9 +194,27 @@ export default function blockToolbarPlugin(options = {}) {
           return commands.DELETE_BLOCK;
         } else if (e.keyCode === 8) {
           return commands.BACKSPACE_BLOCK;
+        } else if (e.keyCode === 13) {
+          // Special handling for when the enter key is pressed while an
+          // atomic block is selected. This appears to be a draft-js bug. When
+          // this situation occurs the atomic block duplicated (though its
+          // entity does not). There's no way to do this so we just have to
+          // *immediately* reverse its function
+          const editorState = getEditorState();
+          window.requestAnimationFrame(() => {
+            setEditorState(
+              insertBlockAfterCurrentBlock(
+                editorState,
+                "unstyled",
+                editableBlockTypes,
+                true
+              )
+            );
+          });
         } else {
           const editorState = getEditorState();
-          // Move the selection to the block below so that the content pla
+          // Move the selection to the block below so that the content comes
+          // through there instead
           const selection = editorState.getSelection();
           let contentState = editorState.getCurrentContent();
           const nextBlockKey = getNextBlockKey(


### PR DESCRIPTION
Special handling for when the enter key is pressed while an atomic block is selected. This appears to be a draft-js bug. When this situation occurs the atomic block duplicated (though its entity does not). There's no way to do this so we just have to *immediately* reverse its function.