### PR TITLE
Rich text editor fixes

### DIFF
--- a/lib/components/ui/dropzone/index.js
+++ b/lib/components/ui/dropzone/index.js
@@ -50,22 +50,26 @@ var _class = function (_React$Component) {
     }, _this.onDragStart = function (e) {
       e.dataTransfer.effectAllowed = "move";
     }, _this.onDrop = function (files) {
+      _this._focusHack.focus();
       var onChange = _this.props.onChange;
 
       if (typeof onChange === "function") onChange(files);
       _this.setState({
         files: files
       });
-    }, _this.onClick = function (e) {
+    }, _this.onButtonClick = function (e) {
       e.preventDefault();
+      _this._focusHack.focus();
       _this._dropzone.open();
+    }, _this.onClick = function (e) {
+      _this._focusHack.focus();
     }, _this.renderPreview = function (files) {
       return React.createElement(
         "div",
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 133
+            lineNumber: 144
           },
           __self: _this2
         },
@@ -74,7 +78,7 @@ var _class = function (_React$Component) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 134
+              lineNumber: 145
             },
             __self: _this2
           },
@@ -87,14 +91,14 @@ var _class = function (_React$Component) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 135
+              lineNumber: 146
             },
             __self: _this2
           },
           files.map(function (file, i) {
             return React.createElement("img", { key: i, alt: "", src: file.preview, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 136
+                lineNumber: 147
               },
               __self: _this2
             });
@@ -104,9 +108,9 @@ var _class = function (_React$Component) {
     }, _this.renderButton = function (buttonText) {
       return React.createElement(
         "button",
-        { onClick: _this.onClick, className: styles.dropzone__button, __source: {
+        { onClick: _this.onButtonClick, className: styles.dropzone__button, __source: {
             fileName: _jsxFileName,
-            lineNumber: 151
+            lineNumber: 162
           },
           __self: _this2
         },
@@ -117,7 +121,7 @@ var _class = function (_React$Component) {
         "span",
         { className: styles.dropzone__label__wrapper, __source: {
             fileName: _jsxFileName,
-            lineNumber: 166
+            lineNumber: 177
           },
           __self: _this2
         },
@@ -125,7 +129,7 @@ var _class = function (_React$Component) {
           "span",
           { className: styles.dropzone__label, __source: {
               fileName: _jsxFileName,
-              lineNumber: 167
+              lineNumber: 178
             },
             __self: _this2
           },
@@ -191,10 +195,17 @@ var _class = function (_React$Component) {
      */
 
     /**
+     * onButtonClick
+     * Open the dropzone
+     * @param  {event} e
+     */
+
+    /**
      * onClick
      * Open the dropzone
      * @param  {event} e
      */
+
 
     /**
      * renderPreview
@@ -252,15 +263,20 @@ var _class = function (_React$Component) {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 198
+            lineNumber: 209
           },
           __self: this
         },
         React.createElement(
           "div",
-          { className: "dropzone__container", __source: {
+          {
+            className: styles.dropzoneContainer,
+            ref: function ref(r) {
+              _this3._focusHack = r;
+            },
+            tabIndex: "0", __source: {
               fileName: _jsxFileName,
-              lineNumber: 199
+              lineNumber: 210
             },
             __self: this
           },
@@ -277,10 +293,11 @@ var _class = function (_React$Component) {
               multiple: multiple,
               onDragStart: this.onDragStart,
               onDrop: this.onDrop,
+              onClick: this.onClick,
               style: {},
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 202
+                lineNumber: 218
               },
               __self: this
             },

--- a/lib/components/ui/dropzone/styles.js
+++ b/lib/components/ui/dropzone/styles.js
@@ -2,6 +2,8 @@ import uid from "uid";
 import { css } from "emotion";
 import { buttons, colours, typography } from "../styles";
 
+export var dropzoneContainer = /*#__PURE__*/css("&:focus{outline:none;}");
+
 /**
  * dropzone
  * this element cannot always be positioned relative.

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
@@ -27,6 +27,7 @@ var AtomicBlock = function (_React$Component) {
   function AtomicBlock(props) {
     _classCallCheck(this, AtomicBlock);
 
+    // Set a per instance ID for talking to the bus
     var _this = _possibleConstructorReturn(this, (AtomicBlock.__proto__ || Object.getPrototypeOf(AtomicBlock)).call(this, props));
 
     _this.onEditorChange = function (editorState) {
@@ -66,13 +67,15 @@ var AtomicBlock = function (_React$Component) {
       _this.setReadOnly(false);
     };
 
-    _this.remove = function () {
+    _this.remove = function (_ref) {
+      var _ref$allowUndo = _ref.allowUndo,
+          allowUndo = _ref$allowUndo === undefined ? true : _ref$allowUndo;
       var _this$props = _this.props,
           block = _this$props.block,
           blockProps = _this$props.blockProps;
 
       _this.setReadOnly(false);
-      blockProps.remove(block.getKey());
+      blockProps.remove(block.getKey(), { allowUndo: allowUndo });
     };
 
     _this.setReadOnly = function (readOnly) {
@@ -81,10 +84,6 @@ var AtomicBlock = function (_React$Component) {
       blockProps.setReadOnly(readOnly);
     };
 
-    _this.entityKey = props.block.getEntityAt(0);
-    _this.entity = Entity.get(_this.entityKey);
-
-    // Set a per instance ID for talking to the bus
     _this.instanceId = uid();
 
     _this.isSelected = false;
@@ -100,7 +99,26 @@ var AtomicBlock = function (_React$Component) {
     value: function componentWillMount() {
       var _this2 = this;
 
+      var block = this.props.block;
       var fieldBus = this.props.blockProps.fieldBus;
+      // Resolve the entity, atomic blocks _must_ have one
+
+      this.entityKey = block.getEntityAt(0);
+      // Remove if there's no key
+      if (this.entityKey == null) {
+        this.remove({ allowUndo: false });
+        return;
+      }
+      this.entity = Entity.get(this.entityKey);
+      // Extract the entity
+      var entityData = this.entity.getData();
+      // If the entity is the wrong _type_, we should remove the block too
+      // our editor expects every atomic block to have an attached entity
+      // of "formalist" type
+      if (this.entity.getType() !== "formalist") {
+        this.remove({ allowUndo: false });
+        return;
+      }
 
       document.addEventListener("mouseup", this.handleOutsideMouseClick);
       document.addEventListener("touchstart", this.handleOutsideMouseClick);
@@ -116,9 +134,6 @@ var AtomicBlock = function (_React$Component) {
         global: globalConfig,
         fields: this.context.globalConfig._fieldsConfig
       });
-
-      // Extract the entity
-      var entityData = this.entity.getData();
 
       // Create the formalist form with config
       this.form = configuredTemplate(entityData.form);
@@ -197,6 +212,11 @@ var AtomicBlock = function (_React$Component) {
     value: function render() {
       var _this3 = this;
 
+      // Don't render if we have no entity
+      if (!this.entity || this.entity.getType() !== "formalist") {
+        return null;
+      }
+
       var _entity$getData = this.entity.getData(),
           label = _entity$getData.label;
 
@@ -212,7 +232,7 @@ var AtomicBlock = function (_React$Component) {
           "data-debug-block-key": this.props.block.getKey(),
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 188
+            lineNumber: 207
           },
           __self: this
         },
@@ -220,14 +240,14 @@ var AtomicBlock = function (_React$Component) {
           "div",
           { className: styles.caret, __source: {
               fileName: _jsxFileName,
-              lineNumber: 193
+              lineNumber: 212
             },
             __self: this
           },
           React.createElement("br", {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 194
+              lineNumber: 213
             },
             __self: this
           })
@@ -245,7 +265,7 @@ var AtomicBlock = function (_React$Component) {
             contentEditable: false,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 196
+              lineNumber: 215
             },
             __self: this
           },
@@ -253,7 +273,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.header, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 206
+                lineNumber: 225
               },
               __self: this
             },
@@ -261,7 +281,7 @@ var AtomicBlock = function (_React$Component) {
               "h3",
               { className: styles.label, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 207
+                  lineNumber: 226
                 },
                 __self: this
               },
@@ -271,7 +291,7 @@ var AtomicBlock = function (_React$Component) {
               "div",
               { className: styles.toolbar, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 208
+                  lineNumber: 227
                 },
                 __self: this
               },
@@ -286,7 +306,7 @@ var AtomicBlock = function (_React$Component) {
                   },
                   __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 209
+                    lineNumber: 228
                   },
                   __self: this
                 },
@@ -294,7 +314,7 @@ var AtomicBlock = function (_React$Component) {
                   "span",
                   { className: styles.removeText, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 217
+                      lineNumber: 236
                     },
                     __self: this
                   },
@@ -304,7 +324,7 @@ var AtomicBlock = function (_React$Component) {
                   "div",
                   { className: styles.removeX, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 218
+                      lineNumber: 237
                     },
                     __self: this
                   },
@@ -317,7 +337,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.content, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 222
+                lineNumber: 241
               },
               __self: this
             },

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
@@ -67,9 +67,11 @@ var AtomicBlock = function (_React$Component) {
       _this.setReadOnly(false);
     };
 
-    _this.remove = function (_ref) {
-      var _ref$allowUndo = _ref.allowUndo,
-          allowUndo = _ref$allowUndo === undefined ? true : _ref$allowUndo;
+    _this.remove = function () {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var allowUndo = options.allowUndo;
+
+      allowUndo = allowUndo === null ? true : allowUndo;
       var _this$props = _this.props,
           block = _this$props.block,
           blockProps = _this$props.blockProps;
@@ -232,7 +234,7 @@ var AtomicBlock = function (_React$Component) {
           "data-debug-block-key": this.props.block.getKey(),
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 207
+            lineNumber: 209
           },
           __self: this
         },
@@ -240,14 +242,14 @@ var AtomicBlock = function (_React$Component) {
           "div",
           { className: styles.caret, __source: {
               fileName: _jsxFileName,
-              lineNumber: 212
+              lineNumber: 214
             },
             __self: this
           },
           React.createElement("br", {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 213
+              lineNumber: 215
             },
             __self: this
           })
@@ -265,7 +267,7 @@ var AtomicBlock = function (_React$Component) {
             contentEditable: false,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 215
+              lineNumber: 217
             },
             __self: this
           },
@@ -273,7 +275,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.header, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 225
+                lineNumber: 227
               },
               __self: this
             },
@@ -281,7 +283,7 @@ var AtomicBlock = function (_React$Component) {
               "h3",
               { className: styles.label, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 226
+                  lineNumber: 228
                 },
                 __self: this
               },
@@ -291,7 +293,7 @@ var AtomicBlock = function (_React$Component) {
               "div",
               { className: styles.toolbar, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 227
+                  lineNumber: 229
                 },
                 __self: this
               },
@@ -306,7 +308,7 @@ var AtomicBlock = function (_React$Component) {
                   },
                   __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 228
+                    lineNumber: 230
                   },
                   __self: this
                 },
@@ -314,7 +316,7 @@ var AtomicBlock = function (_React$Component) {
                   "span",
                   { className: styles.removeText, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 236
+                      lineNumber: 238
                     },
                     __self: this
                   },
@@ -324,7 +326,7 @@ var AtomicBlock = function (_React$Component) {
                   "div",
                   { className: styles.removeX, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 237
+                      lineNumber: 239
                     },
                     __self: this
                   },
@@ -337,7 +339,7 @@ var AtomicBlock = function (_React$Component) {
             "div",
             { className: styles.content, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 241
+                lineNumber: 243
               },
               __self: this
             },

--- a/src/components/ui/dropzone/index.js
+++ b/src/components/ui/dropzone/index.js
@@ -101,6 +101,7 @@ export default class extends React.Component {
    */
 
   onDrop = files => {
+    this._focusHack.focus();
     const { onChange } = this.props;
     if (typeof onChange === "function") onChange(files);
     this.setState({
@@ -109,14 +110,24 @@ export default class extends React.Component {
   };
 
   /**
-   * onClick
+   * onButtonClick
    * Open the dropzone
    * @param  {event} e
    */
 
-  onClick = e => {
+  onButtonClick = e => {
     e.preventDefault();
+    this._focusHack.focus();
     this._dropzone.open();
+  };
+
+  /**
+   * onClick
+   * Open the dropzone
+   * @param  {event} e
+   */
+  onClick = e => {
+    this._focusHack.focus();
   };
 
   /**
@@ -148,7 +159,7 @@ export default class extends React.Component {
 
   renderButton = buttonText => {
     return (
-      <button onClick={this.onClick} className={styles.dropzone__button}>
+      <button onClick={this.onButtonClick} className={styles.dropzone__button}>
         {buttonText != null ? buttonText : "Upload file"}
       </button>
     );
@@ -196,7 +207,12 @@ export default class extends React.Component {
 
     return (
       <div>
-        <div className="dropzone__container">
+        <div
+          className={styles.dropzoneContainer}
+          ref={r => {
+            this._focusHack = r;
+          }}
+          tabIndex="0">
           {!hideDropZoneBtn ? this.renderButton(buttonText) : null}
 
           <Dropzone
@@ -209,6 +225,7 @@ export default class extends React.Component {
             multiple={multiple}
             onDragStart={this.onDragStart}
             onDrop={this.onDrop}
+            onClick={this.onClick}
             style={{}}
           >
             {children}

--- a/src/components/ui/dropzone/styles.js
+++ b/src/components/ui/dropzone/styles.js
@@ -2,6 +2,12 @@ import uid from "uid";
 import { css } from "emotion";
 import { buttons, colours, typography } from "../styles";
 
+export const dropzoneContainer = css`
+  &:focus {
+    outline: none;
+  }
+`;
+
 /**
  * dropzone
  * this element cannot always be positioned relative.

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/blocks/atomic/index.js
@@ -180,7 +180,9 @@ class AtomicBlock extends React.Component {
     this.setReadOnly(false);
   };
 
-  remove = ({ allowUndo = true }) => {
+  remove = (options = {}) => {
+    let { allowUndo } = options
+    allowUndo = allowUndo === null ? true : allowUndo;
     const { block, blockProps } = this.props;
     this.setReadOnly(false);
     blockProps.remove(block.getKey(), { allowUndo });


### PR DESCRIPTION
Fixes a couple of things in the rich text editor:

* Adds back in the check for invalid atomic block data. This means that issues where atomic block entity data is messed up somehow are at least mitigated by removing the offending block immediately.
* Fixes an issue with upload fields in embedded forms. Because clicking or dragging onto the drop zone wouldn’t trigger a focus the wrapping `draft-js` instance wouldn’t be set to `readOnly` and so would see some of the interaction as “text changes” and destroy the formalist entity definition somehow. We trigger a focus event manually on the drop zone wrapper whenever its interacted with and this bubbles up to give us the necessary lock on the `draft-js` content.