### PR TITLE
Fix up keyboard selection behaviour for tags

### DIFF
--- a/lib/components/fields/tags-field/index.js
+++ b/lib/components/fields/tags-field/index.js
@@ -415,8 +415,10 @@ var TagsField = function (_Component) {
                   var added = _this3.addTag(selection.value);
                   if (added) {
                     _this3.clearInput();
-                    _this3._input.focus();
                     _this3._popunder.closePopunder();
+                    window.requestAnimationFrame(function () {
+                      return _this3._input.focus();
+                    });
                   }
                 },
                 __source: {

--- a/lib/components/fields/tags-field/search-list-styles.js
+++ b/lib/components/fields/tags-field/search-list-styles.js
@@ -1,5 +1,5 @@
 import { css } from "emotion";
 import { colours, typography } from "../../ui/styles";
 
-export var optionButton = /*#__PURE__*/css(typography.small, ";", typography.sans, ";", colours.greyTintBorder, ";", colours.whiteBackground, ";border-width:0;border-bottom-width:1px;border-style:solid;cursor:pointer;display:block;padding:0.7rem 1rem;text-align:left;width:100%;");
+export var optionButton = /*#__PURE__*/css(typography.small, ";", typography.sans, ";", colours.greyTintBorder, ";", colours.whiteBackground, ";border-width:0;border-bottom-width:1px;border-style:solid;cursor:pointer;display:block;padding:0.7rem 1rem;text-align:left;width:100%;&:focus{outline:none;}");
 export var optionButtonFocus = /*#__PURE__*/css("text-decoration:underline;");

--- a/lib/components/fields/tags-field/search-list.js
+++ b/lib/components/fields/tags-field/search-list.js
@@ -99,6 +99,17 @@ var SearchList = function (_Component) {
       abortCurrentSearch(this.currentRequest);
       document.removeEventListener("keydown", this.onKeyDown);
     }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate() {
+      var selectedIndex = this.state.selectedIndex;
+
+      if (selectedIndex > -1) {
+        var buttons = Array.prototype.slice.call(this._list.querySelectorAll("button"));
+        var activeButton = buttons[selectedIndex];
+        activeButton.focus();
+      }
+    }
 
     /**
      * Handle focus and selection of the results list
@@ -237,9 +248,12 @@ var SearchList = function (_Component) {
         return React.createElement(
           "div",
           {
+            ref: function ref(r) {
+              _this2._list = r;
+            },
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 179
+              lineNumber: 190
             },
             __self: this
           },
@@ -254,7 +268,7 @@ var SearchList = function (_Component) {
               "button",
               { key: i, className: buttonClassNames, onClick: onClick, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 190
+                  lineNumber: 205
                 },
                 __self: _this2
               },

--- a/src/components/fields/tags-field/index.js
+++ b/src/components/fields/tags-field/index.js
@@ -281,8 +281,8 @@ class TagsField extends Component {
                     const added = this.addTag(selection.value);
                     if (added) {
                       this.clearInput();
-                      this._input.focus();
                       this._popunder.closePopunder();
+                      window.requestAnimationFrame(() => this._input.focus());
                     }
                   }}
                 />

--- a/src/components/fields/tags-field/search-list-styles.js
+++ b/src/components/fields/tags-field/search-list-styles.js
@@ -14,6 +14,9 @@ export const optionButton = css`
   padding: 0.7rem 1rem;
   text-align: left;
   width: 100%;
+  &:focus {
+    outline: none;
+  }
 `;
 export const optionButtonFocus = css`
   text-decoration: underline;

--- a/src/components/fields/tags-field/search-list.js
+++ b/src/components/fields/tags-field/search-list.js
@@ -73,6 +73,17 @@ class SearchList extends Component {
     document.removeEventListener("keydown", this.onKeyDown);
   }
 
+  componentDidUpdate() {
+    let { selectedIndex } = this.state;
+    if (selectedIndex > -1) {
+      const buttons = Array.prototype.slice.call(
+        this._list.querySelectorAll("button")
+      );
+      const activeButton = buttons[selectedIndex];
+      activeButton.focus();
+    }
+  }
+
   /**
    * Handle focus and selection of the results list
    * @param  {KeyboardEvent} e
@@ -176,7 +187,11 @@ class SearchList extends Component {
     const hasResults = results.length > 0;
     if (hasResults) {
       return (
-        <div>
+        <div
+          ref={r => {
+            this._list = r;
+          }}
+        >
           {results.map((result, i) => {
             const selected = i === selectedIndex;
             const buttonClassNames = classNames(styles.optionButton, {


### PR DESCRIPTION
Keyboard selection of existing tags would result in unwanted behaviour. For example:

1. Typing `foo` and receiving a result for `foobar`
2. Press down to select result and enter to choose
3. Tags `foo` and `foobar` will be added.

This now acts as expected: only `foobar` is added to the selected list.