### PR TITLE
Support passing a time picker time format.

### DIFF
--- a/lib/components/fields/date-time-field/index.js
+++ b/lib/components/fields/date-time-field/index.js
@@ -94,7 +94,7 @@ var DateTimeField = function (_React$Component) {
           "data-field-type": "date-time-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 73
+            lineNumber: 74
           },
           __self: this
         },
@@ -108,7 +108,7 @@ var DateTimeField = function (_React$Component) {
             },
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 78
+              lineNumber: 79
             },
             __self: this
           },
@@ -116,7 +116,7 @@ var DateTimeField = function (_React$Component) {
         ),
         React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 87
+            lineNumber: 88
           },
           __self: this
         }),
@@ -124,7 +124,7 @@ var DateTimeField = function (_React$Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 88
+              lineNumber: 89
             },
             __self: this
           },
@@ -134,16 +134,17 @@ var DateTimeField = function (_React$Component) {
             value: value,
             onChange: this.onChange,
             timeFormat: attributes.time_format,
+            humanTimeFormat: attributes.human_time_format,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 89
+              lineNumber: 90
             },
             __self: this
           })
         ),
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 97
+            lineNumber: 99
           },
           __self: this
         }) : null
@@ -162,6 +163,7 @@ DateTimeField.propTypes = {
     hint: PropTypes.string,
     placeholder: PropTypes.string,
     time_format: PropTypes.string,
+    human_time_format: PropTypes.string,
     inline: PropTypes.bool
   }),
   errors: ImmutablePropTypes.list,

--- a/lib/components/fields/date-time-field/index.js
+++ b/lib/components/fields/date-time-field/index.js
@@ -94,7 +94,7 @@ var DateTimeField = function (_React$Component) {
           "data-field-type": "date-time-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 72
+            lineNumber: 73
           },
           __self: this
         },
@@ -108,7 +108,7 @@ var DateTimeField = function (_React$Component) {
             },
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 77
+              lineNumber: 78
             },
             __self: this
           },
@@ -116,7 +116,7 @@ var DateTimeField = function (_React$Component) {
         ),
         React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 86
+            lineNumber: 87
           },
           __self: this
         }),
@@ -124,7 +124,7 @@ var DateTimeField = function (_React$Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 87
+              lineNumber: 88
             },
             __self: this
           },
@@ -133,16 +133,17 @@ var DateTimeField = function (_React$Component) {
             placeholder: attributes.placeholder,
             value: value,
             onChange: this.onChange,
+            timeFormat: attributes.time_format,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 88
+              lineNumber: 89
             },
             __self: this
           })
         ),
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 95
+            lineNumber: 97
           },
           __self: this
         }) : null
@@ -160,6 +161,7 @@ DateTimeField.propTypes = {
     label: PropTypes.string,
     hint: PropTypes.string,
     placeholder: PropTypes.string,
+    time_format: PropTypes.string,
     inline: PropTypes.bool
   }),
   errors: ImmutablePropTypes.list,

--- a/lib/components/ui/date-time-picker/index.js
+++ b/lib/components/ui/date-time-picker/index.js
@@ -140,7 +140,8 @@ var DateTimePicker = function (_React$Component) {
           error = _props.error,
           id = _props.id,
           placeholder = _props.placeholder,
-          timeFormat = _props.timeFormat;
+          timeFormat = _props.timeFormat,
+          humanTimeFormat = _props.humanTimeFormat;
 
 
       var dateValue = this.state.date;
@@ -150,7 +151,7 @@ var DateTimePicker = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 142
+            lineNumber: 143
           },
           __self: this
         },
@@ -158,7 +159,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.datePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 143
+              lineNumber: 144
             },
             __self: this
           },
@@ -170,7 +171,7 @@ var DateTimePicker = function (_React$Component) {
             onChange: this.onDateChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 144
+              lineNumber: 145
             },
             __self: this
           })
@@ -179,7 +180,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.timePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 152
+              lineNumber: 153
             },
             __self: this
           },
@@ -188,10 +189,10 @@ var DateTimePicker = function (_React$Component) {
             value: timeValue,
             onChange: this.onTimeChange,
             timeFormat: timeFormat,
-            humanTimeFormat: timeFormat,
+            humanTimeFormat: humanTimeFormat,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 153
+              lineNumber: 154
             },
             __self: this
           })
@@ -209,7 +210,8 @@ DateTimePicker.propTypes = {
   id: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
-  timeFormat: PropTypes.string
+  timeFormat: PropTypes.string,
+  humanTimeFormat: PropTypes.string
 };
 
 

--- a/lib/components/ui/date-time-picker/index.js
+++ b/lib/components/ui/date-time-picker/index.js
@@ -139,7 +139,8 @@ var DateTimePicker = function (_React$Component) {
       var _props = this.props,
           error = _props.error,
           id = _props.id,
-          placeholder = _props.placeholder;
+          placeholder = _props.placeholder,
+          timeFormat = _props.timeFormat;
 
 
       var dateValue = this.state.date;
@@ -149,7 +150,7 @@ var DateTimePicker = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 141
+            lineNumber: 142
           },
           __self: this
         },
@@ -157,7 +158,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.datePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 142
+              lineNumber: 143
             },
             __self: this
           },
@@ -169,7 +170,7 @@ var DateTimePicker = function (_React$Component) {
             onChange: this.onDateChange,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 143
+              lineNumber: 144
             },
             __self: this
           })
@@ -178,7 +179,7 @@ var DateTimePicker = function (_React$Component) {
           "div",
           { className: styles.timePicker, __source: {
               fileName: _jsxFileName,
-              lineNumber: 151
+              lineNumber: 152
             },
             __self: this
           },
@@ -186,9 +187,11 @@ var DateTimePicker = function (_React$Component) {
             error: error,
             value: timeValue,
             onChange: this.onTimeChange,
+            timeFormat: timeFormat,
+            humanTimeFormat: timeFormat,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 152
+              lineNumber: 153
             },
             __self: this
           })
@@ -205,7 +208,8 @@ DateTimePicker.propTypes = {
   error: PropTypes.bool,
   id: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  timeFormat: PropTypes.string
 };
 
 

--- a/lib/components/ui/time-picker/index.js
+++ b/lib/components/ui/time-picker/index.js
@@ -23,11 +23,6 @@ import Input from "../input";
 // Styles
 import * as styles from "./styles";
 
-var dateFormats = {
-  time: "HH:mm:ss",
-  humanTime: "hh:mma"
-};
-
 var TimePicker = function (_React$Component) {
   _inherits(TimePicker, _React$Component);
 
@@ -39,9 +34,12 @@ var TimePicker = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (TimePicker.__proto__ || Object.getPrototypeOf(TimePicker)).call(this, props));
 
     _this.onInputChange = function (e, value) {
-      var time = moment(value, dateFormats.humanTime);
-      _this.time = time;
-      _this.props.onChange(time.format(dateFormats.time));
+      var time = moment(value, _this.props.humanTimeFormat, true);
+
+      if (time.isValid()) {
+        _this.time = time;
+        _this.props.onChange(time.format(_this.props.timeFormat));
+      }
     };
 
     _this.onInputFocus = function () {
@@ -52,9 +50,9 @@ var TimePicker = function (_React$Component) {
       e.preventDefault();
       _this.time = time;
       _this.setState({
-        inputValue: time.format(dateFormats.humanTime)
+        inputValue: time.format(_this.props.humanTimeFormat)
       });
-      _this.props.onChange(time.format(dateFormats.time));
+      _this.props.onChange(time.format(_this.props.timeFormat));
     };
 
     _this.renderTimeList = function () {
@@ -71,7 +69,7 @@ var TimePicker = function (_React$Component) {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 89
+            lineNumber: 92
           },
           __self: _this2
         },
@@ -90,7 +88,7 @@ var TimePicker = function (_React$Component) {
           "li",
           { key: date.format(), className: styles.item, __source: {
               fileName: _jsxFileName,
-              lineNumber: 113
+              lineNumber: 116
             },
             __self: _this2
           },
@@ -104,11 +102,11 @@ var TimePicker = function (_React$Component) {
               onClick: onClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 114
+                lineNumber: 117
               },
               __self: _this2
             },
-            date.format(dateFormats.humanTime)
+            date.format(_this.props.humanTimeFormat)
           )
         );
         items.push(item);
@@ -128,10 +126,10 @@ var TimePicker = function (_React$Component) {
     };
 
     var inputValue = void 0;
-    var parsedTime = moment(props.value, dateFormats.time);
+    var parsedTime = moment(props.value, props.timeFormat);
     if (parsedTime.isValid()) {
       _this.time = parsedTime;
-      inputValue = parsedTime.format(dateFormats.humanTime);
+      inputValue = parsedTime.format(props.humanTimeFormat);
     }
 
     _this.state = {
@@ -144,11 +142,11 @@ var TimePicker = function (_React$Component) {
     key: "componentWillReceiveProps",
     value: function componentWillReceiveProps(nextProps) {
       if (nextProps.value && nextProps.value !== this.props.value) {
-        var parsedTime = moment(nextProps.value, dateFormats.time);
+        var parsedTime = moment(nextProps.value, this.props.timeFormat);
         if (parsedTime.isValid()) {
           this.time = parsedTime;
           this.setState({
-            inputValue: parsedTime.format(dateFormats.humanTime)
+            inputValue: parsedTime.format(this.props.humanTimeFormat)
           });
         }
       }
@@ -184,7 +182,7 @@ var TimePicker = function (_React$Component) {
         "div",
         { className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 146
+            lineNumber: 149
           },
           __self: this
         },
@@ -199,7 +197,7 @@ var TimePicker = function (_React$Component) {
             onOpen: this.onPopunderOpen,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 147
+              lineNumber: 150
             },
             __self: this
           },
@@ -213,7 +211,7 @@ var TimePicker = function (_React$Component) {
             "data-field-input": "time",
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 155
+              lineNumber: 158
             },
             __self: this
           }),
@@ -230,10 +228,14 @@ TimePicker.propTypes = {
   value: PropTypes.string,
   error: PropTypes.bool,
   onChange: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  timeFormat: PropTypes.string,
+  humanTimeFormat: PropTypes.string
 };
 TimePicker.defaultProps = {
-  placeholder: "Select or enter a time"
+  placeholder: "Select or enter a time",
+  timeFormat: "HH:mm:ss",
+  humanTimeFormat: "hh:mma"
 };
 
 

--- a/src/components/fields/date-time-field/index.js
+++ b/src/components/fields/date-time-field/index.js
@@ -23,6 +23,7 @@ class DateTimeField extends React.Component {
       hint: PropTypes.string,
       placeholder: PropTypes.string,
       time_format: PropTypes.string,
+      human_time_format: PropTypes.string,
       inline: PropTypes.bool
     }),
     errors: ImmutablePropTypes.list,
@@ -92,6 +93,7 @@ class DateTimeField extends React.Component {
             value={value}
             onChange={this.onChange}
             timeFormat={attributes.time_format}
+            humanTimeFormat={attributes.human_time_format}
           />
         </div>
         {hasErrors ? <FieldErrors errors={errors} /> : null}

--- a/src/components/fields/date-time-field/index.js
+++ b/src/components/fields/date-time-field/index.js
@@ -22,6 +22,7 @@ class DateTimeField extends React.Component {
       label: PropTypes.string,
       hint: PropTypes.string,
       placeholder: PropTypes.string,
+      time_format: PropTypes.string,
       inline: PropTypes.bool
     }),
     errors: ImmutablePropTypes.list,
@@ -90,6 +91,7 @@ class DateTimeField extends React.Component {
             placeholder={attributes.placeholder}
             value={value}
             onChange={this.onChange}
+            timeFormat={attributes.time_format}
           />
         </div>
         {hasErrors ? <FieldErrors errors={errors} /> : null}

--- a/src/components/ui/date-time-picker/index.js
+++ b/src/components/ui/date-time-picker/index.js
@@ -23,7 +23,8 @@ class DateTimePicker extends React.Component {
     id: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
-    timeFormat: PropTypes.string
+    timeFormat: PropTypes.string,
+    humanTimeFormat: PropTypes.string
   };
 
   constructor(props) {
@@ -133,7 +134,7 @@ class DateTimePicker extends React.Component {
   };
 
   render() {
-    let { error, id, placeholder, timeFormat } = this.props;
+    let { error, id, placeholder, timeFormat, humanTimeFormat } = this.props;
 
     let dateValue = this.state.date;
     let timeValue = this.state.time;
@@ -155,7 +156,7 @@ class DateTimePicker extends React.Component {
             value={timeValue}
             onChange={this.onTimeChange}
             timeFormat={timeFormat}
-            humanTimeFormat={timeFormat}
+            humanTimeFormat={humanTimeFormat}
           />
         </div>
       </div>

--- a/src/components/ui/date-time-picker/index.js
+++ b/src/components/ui/date-time-picker/index.js
@@ -22,7 +22,8 @@ class DateTimePicker extends React.Component {
     error: PropTypes.bool,
     id: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+    timeFormat: PropTypes.string
   };
 
   constructor(props) {
@@ -132,7 +133,7 @@ class DateTimePicker extends React.Component {
   };
 
   render() {
-    let { error, id, placeholder } = this.props;
+    let { error, id, placeholder, timeFormat } = this.props;
 
     let dateValue = this.state.date;
     let timeValue = this.state.time;
@@ -153,6 +154,8 @@ class DateTimePicker extends React.Component {
             error={error}
             value={timeValue}
             onChange={this.onTimeChange}
+            timeFormat={timeFormat}
+            humanTimeFormat={timeFormat}
           />
         </div>
       </div>

--- a/src/components/ui/time-picker/index.js
+++ b/src/components/ui/time-picker/index.js
@@ -11,30 +11,30 @@ import Input from "../input";
 // Styles
 import * as styles from "./styles";
 
-const dateFormats = {
-  time: "HH:mm:ss",
-  humanTime: "hh:mma"
-};
-
 class TimePicker extends React.Component {
   static propTypes = {
     value: PropTypes.string,
     error: PropTypes.bool,
     onChange: PropTypes.func,
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+    timeFormat: PropTypes.string,
+    humanTimeFormat: PropTypes.string
   };
 
   static defaultProps = {
-    placeholder: "Select or enter a time"
+    placeholder: "Select or enter a time",
+    timeFormat: "HH:mm:ss",
+    humanTimeFormat: "hh:mma"
   };
 
   constructor(props) {
     super(props);
+
     let inputValue;
-    let parsedTime = moment(props.value, dateFormats.time);
+    let parsedTime = moment(props.value, props.timeFormat);
     if (parsedTime.isValid()) {
       this.time = parsedTime;
-      inputValue = parsedTime.format(dateFormats.humanTime);
+      inputValue = parsedTime.format(props.humanTimeFormat);
     }
 
     this.state = {
@@ -44,20 +44,23 @@ class TimePicker extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.value && nextProps.value !== this.props.value) {
-      let parsedTime = moment(nextProps.value, dateFormats.time);
+      let parsedTime = moment(nextProps.value, this.props.timeFormat);
       if (parsedTime.isValid()) {
         this.time = parsedTime;
         this.setState({
-          inputValue: parsedTime.format(dateFormats.humanTime)
+          inputValue: parsedTime.format(this.props.humanTimeFormat)
         });
       }
     }
   }
 
   onInputChange = (e, value) => {
-    let time = moment(value, dateFormats.humanTime);
-    this.time = time;
-    this.props.onChange(time.format(dateFormats.time));
+    let time = moment(value, this.props.humanTimeFormat, true);
+
+    if (time.isValid()) {
+      this.time = time;
+      this.props.onChange(time.format(this.props.timeFormat));
+    }
   };
 
   onInputFocus = () => {
@@ -68,9 +71,9 @@ class TimePicker extends React.Component {
     e.preventDefault();
     this.time = time;
     this.setState({
-      inputValue: time.format(dateFormats.humanTime)
+      inputValue: time.format(this.props.humanTimeFormat)
     });
-    this.props.onChange(time.format(dateFormats.time));
+    this.props.onChange(time.format(this.props.timeFormat));
   };
 
   /**
@@ -118,7 +121,7 @@ class TimePicker extends React.Component {
             className={buttonClassNames}
             onClick={onClick}
           >
-            {date.format(dateFormats.humanTime)}
+            {date.format(this.props.humanTimeFormat)}
           </button>
         </li>
       );


### PR DESCRIPTION
This adds support for optionally specifying the time format (both machine and human) for the time picker.

The Ruby field looks like this:

```
date_time_field :starts_at,
  label: "Start time",
  hint: "A field with seconds",
  time_format: "HH:mm:ss"
```

Not sure whether it's worth being able to separately provide `timeFormat` and `humanTimeFormat` @makenosound? 

I also modified `onInputChange` to wait for a _strictly_ parsable time, which helps when people want to key the time manually, otherwise moment gets a bit happy to parse loosely 'correct' times from underneath you. 

<img width="524" alt="screen shot 2018-07-16 at 9 49 51 pm" src="https://user-images.githubusercontent.com/3338621/42757209-7c29af18-8942-11e8-8a48-7ae035e09a97.png">
