### PR TITLE
Sortable adjustments

### DIFF
--- a/lib/components/fields/multi-selection-field/index.js
+++ b/lib/components/fields/multi-selection-field/index.js
@@ -247,7 +247,9 @@ var SelectionField = function (_React$Component) {
       var _state = this.state,
           search = _state.search,
           searchFocus = _state.searchFocus;
-      var options = attributes.options,
+      var sortable = attributes.sortable,
+          max_height = attributes.max_height,
+          options = attributes.options,
           placeholder = attributes.placeholder,
           selector_label = attributes.selector_label,
           render_selection_as = attributes.render_selection_as,
@@ -319,13 +321,13 @@ var SelectionField = function (_React$Component) {
             onClick: onClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 278
+              lineNumber: 282
             },
             __self: _this3
           },
           React.createElement(Option, { option: option, __source: {
               fileName: _jsxFileName,
-              lineNumber: 283
+              lineNumber: 287
             },
             __self: _this3
           })
@@ -340,7 +342,7 @@ var SelectionField = function (_React$Component) {
           "data-field-type": "multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 289
+            lineNumber: 293
           },
           __self: this
         },
@@ -348,13 +350,13 @@ var SelectionField = function (_React$Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 294
+              lineNumber: 298
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 295
+              lineNumber: 299
             },
             __self: this
           })
@@ -364,7 +366,7 @@ var SelectionField = function (_React$Component) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 297
+              lineNumber: 301
             },
             __self: this
           },
@@ -372,7 +374,7 @@ var SelectionField = function (_React$Component) {
             "div",
             { className: styles.display, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 298
+                lineNumber: 302
               },
               __self: this
             },
@@ -380,7 +382,7 @@ var SelectionField = function (_React$Component) {
               "button",
               { className: styles.wrapper, onClick: this.onChooseClick, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 299
+                  lineNumber: 303
                 },
                 __self: this
               },
@@ -388,7 +390,7 @@ var SelectionField = function (_React$Component) {
                 "div",
                 { className: styles.selectionPlaceholder, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 300
+                    lineNumber: 304
                   },
                   __self: this
                 },
@@ -397,7 +399,7 @@ var SelectionField = function (_React$Component) {
                   {
                     __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 301
+                      lineNumber: 305
                     },
                     __self: this
                   },
@@ -418,7 +420,7 @@ var SelectionField = function (_React$Component) {
                   closeOnOutsideClick: true,
                   __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 308
+                    lineNumber: 312
                   },
                   __self: this
                 },
@@ -426,7 +428,7 @@ var SelectionField = function (_React$Component) {
                   "div",
                   { className: styles.openSelectorButton, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 318
+                      lineNumber: 322
                     },
                     __self: this
                   },
@@ -436,7 +438,7 @@ var SelectionField = function (_React$Component) {
                   "div",
                   { className: styles.options, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 321
+                      lineNumber: 325
                     },
                     __self: this
                   },
@@ -452,7 +454,7 @@ var SelectionField = function (_React$Component) {
                     onChange: this.onSearchChange,
                     __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 322
+                      lineNumber: 326
                     },
                     __self: this
                   }),
@@ -460,7 +462,7 @@ var SelectionField = function (_React$Component) {
                     "div",
                     { className: styles.optionsList, __source: {
                         fileName: _jsxFileName,
-                        lineNumber: 331
+                        lineNumber: 335
                       },
                       __self: this
                     },
@@ -468,7 +470,7 @@ var SelectionField = function (_React$Component) {
                       "p",
                       { className: styles.noResults, __source: {
                           fileName: _jsxFileName,
-                          lineNumber: 335
+                          lineNumber: 339
                         },
                         __self: this
                       },
@@ -483,22 +485,28 @@ var SelectionField = function (_React$Component) {
             "div",
             { className: styles.selectedItems, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 343
+                lineNumber: 347
               },
               __self: this
             },
             React.createElement(
               Sortable,
-              { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop, __source: {
+              {
+                canRemove: true,
+                onRemove: this.onRemove,
+                onDrop: this.onDrop,
+                canSort: sortable,
+                maxHeight: max_height,
+                __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 344
+                  lineNumber: 348
                 },
                 __self: this
               },
               selections.map(function (option, index) {
                 return React.createElement(Selection, { key: index + "_" + option.id, option: option, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 346
+                    lineNumber: 356
                   },
                   __self: _this3
                 });
@@ -507,7 +515,7 @@ var SelectionField = function (_React$Component) {
           ) : null,
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 351
+              lineNumber: 361
             },
             __self: this
           }) : null
@@ -524,14 +532,16 @@ SelectionField.propTypes = {
   name: PropTypes.string,
   config: PropTypes.object,
   attributes: PropTypes.shape({
-    label: PropTypes.string,
     hint: PropTypes.string,
-    placeholder: PropTypes.string,
-    options: PropTypes.array,
     inline: PropTypes.bool,
-    selector_label: PropTypes.string,
+    label: PropTypes.string,
+    sortable: PropTypes.bool,
+    max_height: PropTypes.string,
+    options: PropTypes.array,
+    placeholder: PropTypes.string,
     render_option_as: PropTypes.string,
-    render_selection_as: PropTypes.string
+    render_selection_as: PropTypes.string,
+    selector_label: PropTypes.string
   }),
   hint: PropTypes.string,
   label: PropTypes.string,

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -626,7 +626,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 959
+          lineNumber: 961
         },
         __self: this
       });
@@ -724,7 +724,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1094
+            lineNumber: 1098
           },
           __self: this
         },
@@ -733,7 +733,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1099
+              lineNumber: 1103
             },
             __self: this
           },
@@ -742,13 +742,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1100
+                lineNumber: 1104
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1101
+                lineNumber: 1105
               },
               __self: this
             })
@@ -765,7 +765,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1109
+                lineNumber: 1113
               },
               __self: this
             },
@@ -773,7 +773,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1118
+              lineNumber: 1122
             },
             __self: this
           }) : null
@@ -789,8 +789,10 @@ MultiUploadField.displayName = "UploadField";
 MultiUploadField.propTypes = {
   actions: PropTypes.object,
   attributes: PropTypes.shape({
+    sortable: PropTypes.bool,
     max_file_size: PropTypes.number,
     max_file_size_message: PropTypes.string,
+    max_height: PropTypes.string,
     multiple: PropTypes.bool,
     permitted_file_type_message: PropTypes.string,
     permitted_file_type_regex: PropTypes.string,
@@ -1146,7 +1148,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 752
+          lineNumber: 754
         },
         __self: _this6
       },
@@ -1155,7 +1157,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 754
+            lineNumber: 756
           },
           __self: _this6
         },
@@ -1163,7 +1165,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 755
+              lineNumber: 757
             },
             __self: _this6
           },
@@ -1177,7 +1179,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 756
+              lineNumber: 758
             },
             __self: _this6
           },
@@ -1192,7 +1194,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 777
+          lineNumber: 779
         },
         __self: _this6
       },
@@ -1210,7 +1212,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 796
+          lineNumber: 798
         },
         __self: _this6
       },
@@ -1219,7 +1221,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 797
+            lineNumber: 799
           },
           __self: _this6
         },
@@ -1231,7 +1233,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 798
+            lineNumber: 800
           },
           __self: _this6
         },
@@ -1239,7 +1241,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 799
+              lineNumber: 801
             },
             __self: _this6
           },
@@ -1253,7 +1255,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 800
+              lineNumber: 802
             },
             __self: _this6
           },
@@ -1268,7 +1270,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 821
+          lineNumber: 823
         },
         __self: _this6
       },
@@ -1281,7 +1283,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 838
+        lineNumber: 840
       },
       __self: _this6
     });
@@ -1300,7 +1302,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 865
+          lineNumber: 867
         },
         __self: _this6
       },
@@ -1308,7 +1310,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 866
+            lineNumber: 868
           },
           __self: _this6
         },
@@ -1318,7 +1320,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 867
+            lineNumber: 869
           },
           __self: _this6
         },
@@ -1346,7 +1348,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 894
+          lineNumber: 896
         },
         __self: _this6
       },
@@ -1354,7 +1356,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 895
+            lineNumber: 897
           },
           __self: _this6
         },
@@ -1412,6 +1414,8 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.renderFiles = function (files) {
+    var _React$createElement;
+
     var isSortable = _this6.state.uploadQueue.length === 0;
     var _props3 = _this6.props,
         config = _props3.config,
@@ -1431,17 +1435,15 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement(
       Sortable,
-      {
+      (_React$createElement = {
         canRemove: true,
         canSort: isSortable,
         onRemove: _this6.removeFile,
-        onDrop: _this6.onDrop,
-        __source: {
-          fileName: _jsxFileName,
-          lineNumber: 1063
-        },
-        __self: _this6
-      },
+        onDrop: _this6.onDrop
+      }, _defineProperty(_React$createElement, "canSort", attributes.sortable), _defineProperty(_React$createElement, "maxHeight", attributes.max_height), _defineProperty(_React$createElement, "__source", {
+        fileName: _jsxFileName,
+        lineNumber: 1065
+      }), _defineProperty(_React$createElement, "__self", _this6), _React$createElement),
       allFiles
     );
   };

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -377,7 +377,7 @@ var SearchMultiSelectionField = function (_Component) {
           "data-field-type": "search-multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 286
+            lineNumber: 295
           },
           __self: this
         },
@@ -385,13 +385,13 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 291
+              lineNumber: 300
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 292
+              lineNumber: 301
             },
             __self: this
           })
@@ -400,7 +400,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 294
+              lineNumber: 303
             },
             __self: this
           },
@@ -412,7 +412,7 @@ var SearchMultiSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 295
+                lineNumber: 304
               },
               __self: this
             },
@@ -420,7 +420,7 @@ var SearchMultiSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 300
+                  lineNumber: 309
                 },
                 __self: this
               },
@@ -441,7 +441,7 @@ var SearchMultiSelectionField = function (_Component) {
                 testId: "search-multi-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 306
+                  lineNumber: 315
                 },
                 __self: this
               },
@@ -449,7 +449,7 @@ var SearchMultiSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 317
+                    lineNumber: 326
                   },
                   __self: this
                 },
@@ -473,7 +473,7 @@ var SearchMultiSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 320
+                  lineNumber: 329
                 },
                 __self: this
               })
@@ -484,22 +484,32 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 341
+              lineNumber: 350
             },
             __self: this
           },
           React.createElement(
             Sortable,
-            { canRemove: true, onRemove: this.onRemove, onDrop: this.onDrop, __source: {
+            {
+              canRemove: true,
+              onRemove: this.onRemove,
+              onDrop: this.onDrop,
+              canSort: attributes.sortable,
+              maxHeight: attributes.max_height,
+              __source: {
                 fileName: _jsxFileName,
-                lineNumber: 342
+                lineNumber: 351
               },
               __self: this
             },
             selections.map(function (option, index) {
-              return React.createElement(Selection, { key: index + "_" + option.id, option: option, fetchSelectionsData: _this4.fetchSelectionsData, __source: {
+              return React.createElement(Selection, {
+                key: index + "_" + option.id,
+                option: option,
+                fetchSelectionsData: _this4.fetchSelectionsData,
+                __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 344
+                  lineNumber: 359
                 },
                 __self: _this4
               });
@@ -508,7 +518,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 349
+            lineNumber: 368
           },
           __self: this
         }) : null
@@ -541,6 +551,8 @@ SearchMultiSelectionField.propTypes = {
     hint: PropTypes.string,
     placeholder: PropTypes.string,
     inline: PropTypes.bool,
+    sortable: PropTypes.bool,
+    max_height: PropTypes.string,
     search_url: PropTypes.string,
     search_per_page: PropTypes.number,
     search_params: PropTypes.object,

--- a/lib/components/many/index.js
+++ b/lib/components/many/index.js
@@ -193,7 +193,7 @@ var Many = function (_React$Component2) {
         "div",
         { className: styles.base, "data-many": name, __source: {
             fileName: _jsxFileName,
-            lineNumber: 156
+            lineNumber: 158
           },
           __self: this
         },
@@ -201,7 +201,7 @@ var Many = function (_React$Component2) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 157
+              lineNumber: 159
             },
             __self: this
           },
@@ -209,7 +209,7 @@ var Many = function (_React$Component2) {
             "h3",
             { className: labelClassNames, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 158
+                lineNumber: 160
               },
               __self: this
             },
@@ -219,7 +219,7 @@ var Many = function (_React$Component2) {
             "div",
             { className: styles.controls, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 159
+                lineNumber: 161
               },
               __self: this
             },
@@ -227,7 +227,7 @@ var Many = function (_React$Component2) {
               "button",
               { className: styles.addButton, onClick: this.addChild, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 160
+                  lineNumber: 162
                 },
                 __self: this
               },
@@ -241,10 +241,12 @@ var Many = function (_React$Component2) {
             canRemove: true,
             onRemove: this.onRemove,
             onDrop: this.onDrop,
+            canSort: attributes.sortable,
+            maxHeight: attributes.max_height,
             verticalControls: true,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 166
+              lineNumber: 168
             },
             __self: this
           },
@@ -253,7 +255,7 @@ var Many = function (_React$Component2) {
               ManySet,
               { key: contentsKey + "_" + i, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 173
+                  lineNumber: 177
                 },
                 __self: _this3
               },
@@ -264,7 +266,7 @@ var Many = function (_React$Component2) {
           "div",
           { className: styles.placeholder, __source: {
               fileName: _jsxFileName,
-              lineNumber: 177
+              lineNumber: 181
             },
             __self: this
           },
@@ -272,7 +274,7 @@ var Many = function (_React$Component2) {
             "span",
             { className: styles.placeholderText, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 178
+                lineNumber: 182
               },
               __self: this
             },
@@ -286,7 +288,7 @@ var Many = function (_React$Component2) {
               onClick: this.addChild,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 181
+                lineNumber: 185
               },
               __self: this
             },
@@ -295,7 +297,7 @@ var Many = function (_React$Component2) {
         ),
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 189
+            lineNumber: 193
           },
           __self: this
         }) : null
@@ -318,7 +320,9 @@ Many.propTypes = {
   attributes: ImmutablePropTypes.mapContains({
     label: PropTypes.string,
     placeholder: PropTypes.string,
-    action_label: PropTypes.string
+    action_label: PropTypes.string,
+    sortable: PropTypes.bool,
+    max_height: PropTypes.string
   }),
   template: PropTypes.object,
   children: ImmutablePropTypes.list

--- a/lib/components/ui/sortable/index.js
+++ b/lib/components/ui/sortable/index.js
@@ -2,6 +2,8 @@ var _jsxFileName = "src/components/ui/sortable/index.js";
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -10,6 +12,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 import React from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 import uid from "uid";
 import update from "react-addons-update";
 import { DragDropContext } from "react-dnd";
@@ -124,41 +127,55 @@ var Sortable = function (_React$Component) {
           canRemove = _props.canRemove,
           onRemove = _props.onRemove,
           verticalControls = _props.verticalControls,
-          canSort = _props.canSort;
+          canSort = _props.canSort,
+          maxHeight = _props.maxHeight;
 
       var isSortable = !(canSort === false || items.length <= 1);
 
+      var wrapperClassNames = classNames(_defineProperty({}, "" + styles.maxHeightWrapper, maxHeight != null));
+
+      var baseClassNames = classNames(styles.base, _defineProperty({}, "" + styles.maxHeightBase(maxHeight), maxHeight != null));
+
       return React.createElement(
         "div",
-        { className: styles.base, "data-name": "sortable-item", __source: {
+        { className: wrapperClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 119
+            lineNumber: 155
           },
           __self: this
         },
-        items.map(function (item, index) {
-          return React.createElement(
-            Item,
-            {
-              key: instanceKey + "_" + item.originalIndex,
-              instanceKey: instanceKey,
-              moveItem: _this2.moveItem,
-              onDrop: _this2.onDrop,
-              index: index,
-              originalIndex: item.originalIndex,
-              canSort: isSortable,
-              canRemove: canRemove,
-              onRemove: onRemove,
-              verticalControls: verticalControls,
-              __source: {
-                fileName: _jsxFileName,
-                lineNumber: 121
-              },
-              __self: _this2
+        React.createElement(
+          "div",
+          { className: baseClassNames, "data-name": "sortable-item", __source: {
+              fileName: _jsxFileName,
+              lineNumber: 156
             },
-            item.component
-          );
-        })
+            __self: this
+          },
+          items.map(function (item, index) {
+            return React.createElement(
+              Item,
+              {
+                key: instanceKey + "_" + item.originalIndex,
+                instanceKey: instanceKey,
+                moveItem: _this2.moveItem,
+                onDrop: _this2.onDrop,
+                index: index,
+                originalIndex: item.originalIndex,
+                canSort: isSortable,
+                canRemove: canRemove,
+                onRemove: onRemove,
+                verticalControls: verticalControls,
+                __source: {
+                  fileName: _jsxFileName,
+                  lineNumber: 158
+                },
+                __self: _this2
+              },
+              item.component
+            );
+          })
+        )
       );
     }
   }]);
@@ -173,7 +190,19 @@ Sortable.propTypes = {
    * @type {Boolean}
    */
   canRemove: PropTypes.bool,
+  /**
+   * canSort
+   * Indicates whether list is sortable
+   * @type {Boolean}
+   */
+  canSort: PropTypes.bool,
   children: PropTypes.node,
+  /**
+   * maxHeight
+   * CSS max-height value to limit the size of the sortable
+   * @type {String}
+   */
+  maxHeight: PropTypes.string,
   /**
    * onDrop
    * Callback. Fired _after_ the sort is effected
@@ -193,8 +222,16 @@ Sortable.propTypes = {
    * @type {Function}
    */
   onSort: PropTypes.func,
-  canSort: PropTypes.bool,
+  /**
+   * verticalControls
+   * Stack sort controls vertically
+   * @type {Boolean}
+   */
   verticalControls: PropTypes.bool
+};
+Sortable.defaultProps = {
+  canSort: true,
+  verticalControls: false
 };
 
 

--- a/lib/components/ui/sortable/item/index.js
+++ b/lib/components/ui/sortable/item/index.js
@@ -178,7 +178,11 @@ var Item = function (_React$Component) {
           },
           canRemove ? React.createElement(
             "button",
-            { className: styles.remove, onClick: this.onRemoveClick, __source: {
+            {
+              className: styles.remove,
+              onClick: this.onRemoveClick,
+              title: "Remove",
+              __source: {
                 fileName: _jsxFileName,
                 lineNumber: 188
               },
@@ -188,7 +192,7 @@ var Item = function (_React$Component) {
               "span",
               { className: styles.removeText, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 189
+                  lineNumber: 193
                 },
                 __self: this
               },
@@ -198,7 +202,7 @@ var Item = function (_React$Component) {
               "div",
               { className: styles.removeX, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 190
+                  lineNumber: 194
                 },
                 __self: this
               },
@@ -210,9 +214,10 @@ var Item = function (_React$Component) {
             {
               className: styles.handle,
               onClick: this.onHandleClick,
+              title: "Drag to reorder",
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 195
+                lineNumber: 199
               },
               __self: this
             },
@@ -220,7 +225,7 @@ var Item = function (_React$Component) {
               "span",
               { className: styles.handleText, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 199
+                  lineNumber: 204
                 },
                 __self: this
               },
@@ -228,7 +233,7 @@ var Item = function (_React$Component) {
             ),
             React.createElement("div", { className: styles.handleLine, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 200
+                lineNumber: 205
               },
               __self: this
             })

--- a/lib/components/ui/sortable/styles.js
+++ b/lib/components/ui/sortable/styles.js
@@ -2,3 +2,10 @@ import { css } from "emotion";
 import { inputBoxes } from "../styles";
 
 export var base = /*#__PURE__*/css(inputBoxes.inputBox, ";");
+
+export var maxHeightWrapper = /*#__PURE__*/css("position:relative;&:after{background-color:rgba(20,15,10,0.03);bottom:0;content:\"\";display:block;height:2px;left:0;position:absolute;right:0;}");
+
+export var maxHeightBase = function maxHeightBase(maxHeight) {
+  return (/*#__PURE__*/css("max-height:", maxHeight, ";overflow-y:scroll;overflow-x:hidden;overflow-scrolling:touch")
+  );
+};

--- a/src/components/fields/multi-selection-field/index.js
+++ b/src/components/fields/multi-selection-field/index.js
@@ -50,6 +50,7 @@ class SelectionField extends React.Component {
       hint: PropTypes.string,
       inline: PropTypes.bool,
       label: PropTypes.string,
+      sortable: PropTypes.bool,
       max_height: PropTypes.string,
       options: PropTypes.array,
       placeholder: PropTypes.string,
@@ -213,6 +214,7 @@ class SelectionField extends React.Component {
     const { attributes, config, errors, hint, label, name, value } = this.props;
     const { search, searchFocus } = this.state;
     const {
+      sortable,
       max_height,
       options,
       placeholder,
@@ -347,6 +349,7 @@ class SelectionField extends React.Component {
                 canRemove
                 onRemove={this.onRemove}
                 onDrop={this.onDrop}
+                canSort={sortable}
                 maxHeight={max_height}
               >
                 {selections.map((option, index) => (

--- a/src/components/fields/multi-selection-field/index.js
+++ b/src/components/fields/multi-selection-field/index.js
@@ -47,14 +47,15 @@ class SelectionField extends React.Component {
     name: PropTypes.string,
     config: PropTypes.object,
     attributes: PropTypes.shape({
-      label: PropTypes.string,
       hint: PropTypes.string,
-      placeholder: PropTypes.string,
-      options: PropTypes.array,
       inline: PropTypes.bool,
-      selector_label: PropTypes.string,
+      label: PropTypes.string,
+      max_height: PropTypes.string,
+      options: PropTypes.array,
+      placeholder: PropTypes.string,
       render_option_as: PropTypes.string,
-      render_selection_as: PropTypes.string
+      render_selection_as: PropTypes.string,
+      selector_label: PropTypes.string
     }),
     hint: PropTypes.string,
     label: PropTypes.string,
@@ -212,6 +213,7 @@ class SelectionField extends React.Component {
     const { attributes, config, errors, hint, label, name, value } = this.props;
     const { search, searchFocus } = this.state;
     const {
+      max_height,
       options,
       placeholder,
       selector_label,
@@ -341,7 +343,12 @@ class SelectionField extends React.Component {
           </div>
           {numberOfSelections > 0 ? (
             <div className={styles.selectedItems}>
-              <Sortable canRemove onRemove={this.onRemove} onDrop={this.onDrop}>
+              <Sortable
+                canRemove
+                onRemove={this.onRemove}
+                onDrop={this.onDrop}
+                maxHeight={max_height}
+              >
                 {selections.map((option, index) => (
                   <Selection key={`${index}_${option.id}`} option={option} />
                 ))}

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -155,6 +155,7 @@ class MultiUploadField extends React.Component {
   static propTypes = {
     actions: PropTypes.object,
     attributes: PropTypes.shape({
+      sortable: PropTypes.bool,
       max_file_size: PropTypes.number,
       max_file_size_message: PropTypes.string,
       max_height: PropTypes.string,
@@ -1066,6 +1067,7 @@ class MultiUploadField extends React.Component {
         canSort={isSortable}
         onRemove={this.removeFile}
         onDrop={this.onDrop}
+        canSort={attributes.sortable}
         maxHeight={attributes.max_height}
       >
         {allFiles}

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -157,6 +157,7 @@ class MultiUploadField extends React.Component {
     attributes: PropTypes.shape({
       max_file_size: PropTypes.number,
       max_file_size_message: PropTypes.string,
+      max_height: PropTypes.string,
       multiple: PropTypes.bool,
       permitted_file_type_message: PropTypes.string,
       permitted_file_type_regex: PropTypes.string,
@@ -1065,6 +1066,7 @@ class MultiUploadField extends React.Component {
         canSort={isSortable}
         onRemove={this.removeFile}
         onDrop={this.onDrop}
+        maxHeight={attributes.max_height}
       >
         {allFiles}
       </Sortable>

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -352,6 +352,7 @@ class SearchMultiSelectionField extends Component {
               canRemove
               onRemove={this.onRemove}
               onDrop={this.onDrop}
+              canSort={attributes.sortable}
               maxHeight={attributes.max_height}
             >
               {selections.map((option, index) => (
@@ -390,6 +391,7 @@ SearchMultiSelectionField.propTypes = {
     hint: PropTypes.string,
     placeholder: PropTypes.string,
     inline: PropTypes.bool,
+    sortable: PropTypes.bool,
     max_height: PropTypes.string,
     search_url: PropTypes.string,
     search_per_page: PropTypes.number,

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -242,13 +242,21 @@ class SearchMultiSelectionField extends Component {
   }
 
   render() {
-    const { attributes, config, errors, hint, label, name, value } = this.props;
+    const {
+      attributes,
+      config,
+      errors,
+      hint,
+      label,
+      name,
+      value
+    } = this.props;
     const {
       placeholder,
       selector_label,
       render_option_as,
       render_option_control_as,
-      render_selection_as,
+      render_selection_as
     } = attributes;
     const { selections, selectorFocus, selectorQuery } = this.state;
     const hasErrors = errors.count() > 0;
@@ -271,7 +279,8 @@ class SearchMultiSelectionField extends Component {
       }
       if (render_option_control_as) {
         OptionControl =
-          extractComponent(config.components, render_option_control_as) || OptionControl;
+          extractComponent(config.components, render_option_control_as) ||
+          OptionControl;
       }
       if (render_selection_as) {
         Selection =
@@ -339,9 +348,18 @@ class SearchMultiSelectionField extends Component {
         </div>
         {numberOfSelections > 0 ? (
           <div className={styles.selectedItems}>
-            <Sortable canRemove onRemove={this.onRemove} onDrop={this.onDrop}>
+            <Sortable
+              canRemove
+              onRemove={this.onRemove}
+              onDrop={this.onDrop}
+              maxHeight={attributes.max_height}
+            >
               {selections.map((option, index) => (
-                <Selection key={`${index}_${option.id}`} option={option} fetchSelectionsData={this.fetchSelectionsData} />
+                <Selection
+                  key={`${index}_${option.id}`}
+                  option={option}
+                  fetchSelectionsData={this.fetchSelectionsData}
+                />
               ))}
             </Sortable>
           </div>
@@ -372,6 +390,7 @@ SearchMultiSelectionField.propTypes = {
     hint: PropTypes.string,
     placeholder: PropTypes.string,
     inline: PropTypes.bool,
+    max_height: PropTypes.string,
     search_url: PropTypes.string,
     search_per_page: PropTypes.number,
     search_params: PropTypes.object,

--- a/src/components/many/index.js
+++ b/src/components/many/index.js
@@ -43,6 +43,7 @@ class Many extends React.Component {
       label: PropTypes.string,
       placeholder: PropTypes.string,
       action_label: PropTypes.string,
+      sortable: PropTypes.bool,
       max_height: PropTypes.string
     }),
     template: PropTypes.object,
@@ -168,6 +169,7 @@ class Many extends React.Component {
             canRemove
             onRemove={this.onRemove}
             onDrop={this.onDrop}
+            canSort={attributes.sortable}
             maxHeight={attributes.max_height}
             verticalControls
           >

--- a/src/components/many/index.js
+++ b/src/components/many/index.js
@@ -42,7 +42,8 @@ class Many extends React.Component {
     attributes: ImmutablePropTypes.mapContains({
       label: PropTypes.string,
       placeholder: PropTypes.string,
-      action_label: PropTypes.string
+      action_label: PropTypes.string,
+      max_height: PropTypes.string
     }),
     template: PropTypes.object,
     children: ImmutablePropTypes.list
@@ -167,6 +168,7 @@ class Many extends React.Component {
             canRemove
             onRemove={this.onRemove}
             onDrop={this.onDrop}
+            maxHeight={attributes.max_height}
             verticalControls
           >
             {children.map((setChildren, i) => (

--- a/src/components/ui/sortable/index.js
+++ b/src/components/ui/sortable/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 import uid from "uid";
 import update from "react-addons-update";
 import { DragDropContext } from "react-dnd";
@@ -25,7 +26,19 @@ class Sortable extends React.Component {
      * @type {Boolean}
      */
     canRemove: PropTypes.bool,
+    /**
+     * canSort
+     * Indicates whether list is sortable
+     * @type {Boolean}
+     */
+    canSort: PropTypes.bool,
     children: PropTypes.node,
+    /**
+     * maxHeight
+     * CSS max-height value to limit the size of the sortable
+     * @type {String}
+     */
+    maxHeight: PropTypes.string,
     /**
      * onDrop
      * Callback. Fired _after_ the sort is effected
@@ -45,7 +58,11 @@ class Sortable extends React.Component {
      * @type {Function}
      */
     onSort: PropTypes.func,
-    canSort: PropTypes.bool,
+    /**
+     * verticalControls
+     * Stack sort controls vertically
+     * @type {Boolean}
+     */
     verticalControls: PropTypes.bool
   };
 
@@ -112,11 +129,21 @@ class Sortable extends React.Component {
 
   render() {
     const { instanceKey, items } = this.state;
-    const { canRemove, onRemove, verticalControls, canSort } = this.props;
+    const {
+      canRemove,
+      onRemove,
+      verticalControls,
+      canSort,
+      maxHeight
+    } = this.props;
     let isSortable = !(canSort === false || items.length <= 1);
 
+    let baseClassNames = classNames(styles.base, {
+      [`${styles.maxHeight(maxHeight)}`]: maxHeight != null
+    });
+
     return (
-      <div className={styles.base} data-name="sortable-item">
+      <div className={baseClassNames} data-name="sortable-item">
         {items.map((item, index) => (
           <Item
             key={`${instanceKey}_${item.originalIndex}`}

--- a/src/components/ui/sortable/index.js
+++ b/src/components/ui/sortable/index.js
@@ -143,28 +143,34 @@ class Sortable extends React.Component {
     } = this.props;
     let isSortable = !(canSort === false || items.length <= 1);
 
+    let wrapperClassNames = classNames({
+      [`${styles.maxHeightWrapper}`]: maxHeight != null
+    });
+
     let baseClassNames = classNames(styles.base, {
-      [`${styles.maxHeight(maxHeight)}`]: maxHeight != null
+      [`${styles.maxHeightBase(maxHeight)}`]: maxHeight != null
     });
 
     return (
-      <div className={baseClassNames} data-name="sortable-item">
-        {items.map((item, index) => (
-          <Item
-            key={`${instanceKey}_${item.originalIndex}`}
-            instanceKey={instanceKey}
-            moveItem={this.moveItem}
-            onDrop={this.onDrop}
-            index={index}
-            originalIndex={item.originalIndex}
-            canSort={isSortable}
-            canRemove={canRemove}
-            onRemove={onRemove}
-            verticalControls={verticalControls}
-          >
-            {item.component}
-          </Item>
-        ))}
+      <div className={wrapperClassNames}>
+        <div className={baseClassNames} data-name="sortable-item">
+          {items.map((item, index) => (
+            <Item
+              key={`${instanceKey}_${item.originalIndex}`}
+              instanceKey={instanceKey}
+              moveItem={this.moveItem}
+              onDrop={this.onDrop}
+              index={index}
+              originalIndex={item.originalIndex}
+              canSort={isSortable}
+              canRemove={canRemove}
+              onRemove={onRemove}
+              verticalControls={verticalControls}
+            >
+              {item.component}
+            </Item>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/ui/sortable/index.js
+++ b/src/components/ui/sortable/index.js
@@ -66,6 +66,11 @@ class Sortable extends React.Component {
     verticalControls: PropTypes.bool
   };
 
+  static defaultProps = {
+    canSort: true,
+    verticalControls: false
+  };
+
   state = {
     instanceKey: uid(),
     items: React.Children.map(this.props.children, (child, index) => ({

--- a/src/components/ui/sortable/item/index.js
+++ b/src/components/ui/sortable/item/index.js
@@ -185,7 +185,11 @@ class Item extends React.Component {
           <div className={styles.inner}>{children}</div>
           <div className={controlsClasses}>
             {canRemove ? (
-              <button className={styles.remove} onClick={this.onRemoveClick}>
+              <button
+                className={styles.remove}
+                onClick={this.onRemoveClick}
+                title="Remove"
+              >
                 <span className={styles.removeText}>Remove</span>
                 <div className={styles.removeX}>×</div>
               </button>
@@ -195,6 +199,7 @@ class Item extends React.Component {
                   <button
                     className={styles.handle}
                     onClick={this.onHandleClick}
+                    title="Drag to reorder"
                   >
                     <span className={styles.handleText}>Drag to reorder</span>
                     <div className={styles.handleLine} />

--- a/src/components/ui/sortable/styles.js
+++ b/src/components/ui/sortable/styles.js
@@ -5,22 +5,25 @@ export const base = css`
   ${inputBoxes.inputBox};
 `;
 
-export const maxHeight = maxHeight => {
+export const maxHeightWrapper = css`
+  position: relative;
+  &:after {
+    background-color: rgba(20, 15, 10, 0.03);
+    bottom: 0;
+    content: "";
+    display: block;
+    height: 2px;
+    left: 0;
+    position: absolute;
+    right: 0;
+  }
+`;
+
+export const maxHeightBase = maxHeight => {
   return css`
     max-height: ${maxHeight};
     overflow-y: scroll;
     overflow-x: hidden;
     overflow-scrolling: touch
-    position: relative;
-    &:after {
-      background-color: rgba(20, 15, 10, 0.03);
-      bottom: 0;
-      content: "";
-      display: block;
-      height: 2px;
-      left: 0;
-      position: absolute;
-      right: 0;
-    }
   `;
 };

--- a/src/components/ui/sortable/styles.js
+++ b/src/components/ui/sortable/styles.js
@@ -4,3 +4,23 @@ import { inputBoxes } from "../styles";
 export const base = css`
   ${inputBoxes.inputBox};
 `;
+
+export const maxHeight = maxHeight => {
+  return css`
+    max-height: ${maxHeight};
+    overflow-y: scroll;
+    overflow-x: hidden;
+    overflow-scrolling: touch
+    position: relative;
+    &:after {
+      background-color: rgba(20, 15, 10, 0.03);
+      bottom: 0;
+      content: "";
+      display: block;
+      height: 2px;
+      left: 0;
+      position: absolute;
+      right: 0;
+    }
+  `;
+};


### PR DESCRIPTION
Usability adjustments to `<Sortable>` components:

* Allow a `max_height` attribute to be passed through the AST and applied to sortables
* Allow a `sortable` attribute to propagate down to sortables to enable/disable sorting
* Add simple tooltips for sortable controls with `title` attributes (more complex tooltips are awkward because `react-dnd` uses [setDragImage](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage) and so we get awkward overhangs.