### PR TITLE
Add support for clearing search selection queries

### DIFF
--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -83,7 +83,6 @@ var SearchMultiSelectionField = function (_Component) {
 
     _this2.cachedSelections = List();
     _this2.cachedValue = value;
-    _this2.clearQueryOnSelection = true;
 
     // Initial state
     _this2.state = {
@@ -232,6 +231,8 @@ var SearchMultiSelectionField = function (_Component) {
   }, {
     key: "onSelection",
     value: function onSelection(id, selection) {
+      var attributes = this.props.attributes;
+
       var value = this.cachedValue;
       value = value || List();
       // Exists already? Remove it
@@ -241,7 +242,7 @@ var SearchMultiSelectionField = function (_Component) {
       } else {
         this.onChange(value.push(id), this.cachedSelections.push(selection));
       }
-      if (this.clearQueryOnSelection) {
+      if (attributes.clear_query_on_selection) {
         this.setState({
           selectorQuery: null
         });
@@ -553,6 +554,7 @@ SearchMultiSelectionField.propTypes = {
   name: PropTypes.string,
   config: PropTypes.object,
   attributes: PropTypes.shape({
+    clear_query_on_selection: PropTypes.bool,
     label: PropTypes.string,
     hint: PropTypes.string,
     placeholder: PropTypes.string,

--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -83,6 +83,7 @@ var SearchMultiSelectionField = function (_Component) {
 
     _this2.cachedSelections = List();
     _this2.cachedValue = value;
+    _this2.clearQueryOnSelection = true;
 
     // Initial state
     _this2.state = {
@@ -240,6 +241,11 @@ var SearchMultiSelectionField = function (_Component) {
       } else {
         this.onChange(value.push(id), this.cachedSelections.push(selection));
       }
+      if (this.clearQueryOnSelection) {
+        this.setState({
+          selectorQuery: null
+        });
+      }
     }
 
     /**
@@ -377,7 +383,7 @@ var SearchMultiSelectionField = function (_Component) {
           "data-field-type": "search-multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 287
+            lineNumber: 293
           },
           __self: this
         },
@@ -385,13 +391,13 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 292
+              lineNumber: 298
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 293
+              lineNumber: 299
             },
             __self: this
           })
@@ -400,7 +406,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 295
+              lineNumber: 301
             },
             __self: this
           },
@@ -412,7 +418,7 @@ var SearchMultiSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 296
+                lineNumber: 302
               },
               __self: this
             },
@@ -420,7 +426,7 @@ var SearchMultiSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 301
+                  lineNumber: 307
                 },
                 __self: this
               },
@@ -441,7 +447,7 @@ var SearchMultiSelectionField = function (_Component) {
                 testId: "search-multi-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 307
+                  lineNumber: 313
                 },
                 __self: this
               },
@@ -449,7 +455,7 @@ var SearchMultiSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 318
+                    lineNumber: 324
                   },
                   __self: this
                 },
@@ -473,7 +479,7 @@ var SearchMultiSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 321
+                  lineNumber: 327
                 },
                 __self: this
               })
@@ -484,7 +490,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 342
+              lineNumber: 348
             },
             __self: this
           },
@@ -498,7 +504,7 @@ var SearchMultiSelectionField = function (_Component) {
               maxHeight: attributes.max_height,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 343
+                lineNumber: 349
               },
               __self: this
             },
@@ -509,7 +515,7 @@ var SearchMultiSelectionField = function (_Component) {
                 fetchSelectionsData: _this4.fetchSelectionsData,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 351
+                  lineNumber: 357
                 },
                 __self: _this4
               });
@@ -518,7 +524,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 360
+            lineNumber: 366
           },
           __self: this
         }) : null

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -76,6 +76,15 @@ var SearchSelector = function (_Component) {
       }
     }
   }, {
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      // If query updated through props to null
+      if (this.query && nextProps.query == null) {
+        this._search.value = "";
+        this.focusSearch();
+      }
+    }
+  }, {
     key: "componentWillUnmount",
     value: function componentWillUnmount() {
       abortCurrentSearch(this.currentRequest);
@@ -204,13 +213,13 @@ var SearchSelector = function (_Component) {
             onClick: onClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 158
+              lineNumber: 166
             },
             __self: _this2
           },
           React.createElement(Option, { option: option, __source: {
               fileName: _jsxFileName,
-              lineNumber: 164
+              lineNumber: 172
             },
             __self: _this2
           })
@@ -223,7 +232,7 @@ var SearchSelector = function (_Component) {
         "div",
         { "data-search-selector": true, className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 174
+            lineNumber: 182
           },
           __self: this
         },
@@ -241,13 +250,13 @@ var SearchSelector = function (_Component) {
           onChange: this.onSearchChange,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 175
+            lineNumber: 183
           },
           __self: this
         }),
         loading ? React.createElement(Spinner, { className: styles.spinner, __source: {
             fileName: _jsxFileName,
-            lineNumber: 188
+            lineNumber: 196
           },
           __self: this
         }) : null,
@@ -257,7 +266,7 @@ var SearchSelector = function (_Component) {
           onSelection: onSelection,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 190
+            lineNumber: 198
           },
           __self: this
         }) : null,
@@ -265,7 +274,7 @@ var SearchSelector = function (_Component) {
           "div",
           { "data-search-selector-results": true, className: resultClassNames, __source: {
               fileName: _jsxFileName,
-              lineNumber: 197
+              lineNumber: 205
             },
             __self: this
           },
@@ -273,7 +282,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.pagination, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 198
+                lineNumber: 206
               },
               __self: this
             },
@@ -283,7 +292,7 @@ var SearchSelector = function (_Component) {
               goToPage: this.goToPage,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 199
+                lineNumber: 207
               },
               __self: this
             })
@@ -292,7 +301,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.list, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 205
+                lineNumber: 213
               },
               __self: this
             },
@@ -302,7 +311,7 @@ var SearchSelector = function (_Component) {
           "p",
           { className: styles.noResults, __source: {
               fileName: _jsxFileName,
-              lineNumber: 208
+              lineNumber: 216
             },
             __self: this
           },
@@ -358,7 +367,7 @@ function OptionComponent(_ref) {
     {
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 249
+        lineNumber: 257
       },
       __self: this
     },

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -53,6 +53,7 @@ class SearchMultiSelectionField extends Component {
     // Keep value as a cached property
     this.cachedSelections = List();
     this.cachedValue = value;
+    this.clearQueryOnSelection = true;
 
     // Initial state
     this.state = {
@@ -178,6 +179,11 @@ class SearchMultiSelectionField extends Component {
       this.onRemove(index);
     } else {
       this.onChange(value.push(id), this.cachedSelections.push(selection));
+    }
+    if (this.clearQueryOnSelection) {
+      this.setState({
+        selectorQuery: null
+      });
     }
   }
 

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -53,7 +53,6 @@ class SearchMultiSelectionField extends Component {
     // Keep value as a cached property
     this.cachedSelections = List();
     this.cachedValue = value;
-    this.clearQueryOnSelection = true;
 
     // Initial state
     this.state = {
@@ -171,6 +170,7 @@ class SearchMultiSelectionField extends Component {
    * @return {Null}
    */
   onSelection(id, selection) {
+    const { attributes } = this.props;
     let value = this.cachedValue;
     value = value || List();
     // Exists already? Remove it
@@ -180,7 +180,7 @@ class SearchMultiSelectionField extends Component {
     } else {
       this.onChange(value.push(id), this.cachedSelections.push(selection));
     }
-    if (this.clearQueryOnSelection) {
+    if (attributes.clear_query_on_selection) {
       this.setState({
         selectorQuery: null
       });
@@ -385,6 +385,7 @@ SearchMultiSelectionField.propTypes = {
   name: PropTypes.string,
   config: PropTypes.object,
   attributes: PropTypes.shape({
+    clear_query_on_selection: PropTypes.bool,
     label: PropTypes.string,
     hint: PropTypes.string,
     placeholder: PropTypes.string,

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -53,6 +53,14 @@ class SearchSelector extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    // If query updated through props to null
+    if (this.query && nextProps.query == null) {
+      this._search.value = "";
+      this.focusSearch();
+    }
+  }
+
   componentWillUnmount() {
     abortCurrentSearch(this.currentRequest);
   }


### PR DESCRIPTION
This adds support for clearing search selection queries when selection occurs (via a `clear_query_on_selection` attribute), so we can have behaviour as pictured.

![clear-query](https://user-images.githubusercontent.com/3338621/43674014-0e0b266a-9810-11e8-8a34-31ad5eab614e.gif)
