### PR TITLE
Add support for custom upload path builders.

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -589,6 +589,11 @@ var MultiUploadField = function (_React$Component2) {
      * Take a url, path and and optional size (defaults to 'original')
      * Split the path before it's file name.
      * Replace 'upload' with 'view' in the url amd return the string
+     *
+     * Checks for a custom configured path builder and returns that
+     * path builder's output when present. The custom builder must
+     * return a promise.
+     *
      * @param {string} url
      * @param {string} path
      * @param {string} dimension: 'original', '50x', '100x100', '400x100', etc
@@ -626,7 +631,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 962
+          lineNumber: 982
         },
         __self: this
       });
@@ -724,7 +729,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1098
+            lineNumber: 1118
           },
           __self: this
         },
@@ -733,7 +738,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1103
+              lineNumber: 1123
             },
             __self: this
           },
@@ -742,13 +747,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1104
+                lineNumber: 1124
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1105
+                lineNumber: 1125
               },
               __self: this
             })
@@ -765,7 +770,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1113
+                lineNumber: 1133
               },
               __self: this
             },
@@ -773,7 +778,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1122
+              lineNumber: 1142
             },
             __self: this
           }) : null
@@ -799,6 +804,7 @@ MultiUploadField.propTypes = {
     presign_url: PropTypes.string,
     presign_options: PropTypes.object,
     render_uploaded_as: PropTypes.string,
+    path_builder: PropTypes.string,
     upload_action_label: PropTypes.string,
     upload_prompt: PropTypes.string
   }),
@@ -896,23 +902,30 @@ var _initialiseProps = function _initialiseProps() {
       copy.fileAttributes[key] = response[key];
     }
 
-    // apply the 'original_url' to existing `fileAttributes`
-    copy.fileAttributes["original_url"] = _this6.buildPath(upload_url, response.path);
-    if (hasImageFormatType(copy.fileAttributes["file_name"])) {
-      copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
-    }
+    // Build the path. We use a promise so that applications
+    // can provide their own path builder.
+    _this6.buildPath(upload_url, response.path).then(function (path) {
+      // apply the 'original_url' to existing `fileAttributes`
+      copy.fileAttributes["original_url"] = path;
 
-    var files = _this6.state.files.slice(0);
-    var indexOfFile = files.findIndex(function (file) {
-      return file.uid === fileObject.uid;
+      if (hasImageFormatType(copy.fileAttributes["file_name"])) {
+        copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
+      }
+
+      var files = _this6.state.files.slice(0);
+      var indexOfFile = files.findIndex(function (file) {
+        return file.uid === fileObject.uid;
+      });
+      files.splice(indexOfFile, 1, copy);
+
+      _this6.setState({
+        files: files
+      });
+
+      _this6.onUpdate(files);
+    }).catch(function (error) {
+      console.log(error);
     });
-    files.splice(indexOfFile, 1, copy);
-
-    _this6.setState({
-      files: files
-    });
-
-    _this6.onUpdate(files);
   };
 
   this.onUpdate = function (files) {
@@ -1148,7 +1161,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 755
+          lineNumber: 760
         },
         __self: _this6
       },
@@ -1157,7 +1170,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 757
+            lineNumber: 762
           },
           __self: _this6
         },
@@ -1165,7 +1178,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 758
+              lineNumber: 763
             },
             __self: _this6
           },
@@ -1179,7 +1192,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 759
+              lineNumber: 764
             },
             __self: _this6
           },
@@ -1194,7 +1207,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 780
+          lineNumber: 785
         },
         __self: _this6
       },
@@ -1212,7 +1225,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 799
+          lineNumber: 804
         },
         __self: _this6
       },
@@ -1221,7 +1234,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 800
+            lineNumber: 805
           },
           __self: _this6
         },
@@ -1233,7 +1246,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 801
+            lineNumber: 806
           },
           __self: _this6
         },
@@ -1241,7 +1254,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 802
+              lineNumber: 807
             },
             __self: _this6
           },
@@ -1255,7 +1268,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 803
+              lineNumber: 808
             },
             __self: _this6
           },
@@ -1270,7 +1283,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 824
+          lineNumber: 829
         },
         __self: _this6
       },
@@ -1283,7 +1296,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 841
+        lineNumber: 846
       },
       __self: _this6
     });
@@ -1302,7 +1315,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 868
+          lineNumber: 873
         },
         __self: _this6
       },
@@ -1310,7 +1323,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 869
+            lineNumber: 874
           },
           __self: _this6
         },
@@ -1320,7 +1333,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 870
+            lineNumber: 875
           },
           __self: _this6
         },
@@ -1348,7 +1361,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 897
+          lineNumber: 902
         },
         __self: _this6
       },
@@ -1356,7 +1369,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 898
+            lineNumber: 903
           },
           __self: _this6
         },
@@ -1368,17 +1381,29 @@ var _initialiseProps = function _initialiseProps() {
 
   this.buildPath = function (url, path) {
     var dimension = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "original";
+    var _props3 = _this6.props,
+        config = _props3.config,
+        attributes = _props3.attributes;
+    var path_builder = attributes.path_builder;
 
-    var _ref2 = _this6.context.globalConfig || {},
-        uploader = _ref2.uploader;
+    // Any custom path builder must return a promise
 
-    if (uploader === "attache") {
-      var pattern = /([^/]*)$/;
-      var splitPath = path.split(pattern);
-      return url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1];
-    } else {
-      return url + "/" + path;
+    if (_this6.customComponentExists(config, path_builder)) {
+      return extractComponent(config.components, path_builder)(url, path, dimension);
     }
+
+    return new Promise(function (resolve, reject) {
+      var _ref2 = _this6.context.globalConfig || {},
+          uploader = _ref2.uploader;
+
+      if (uploader === "attache") {
+        var pattern = /([^/]*)$/;
+        var splitPath = path.split(pattern);
+        resolve(url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1]);
+      } else {
+        resolve(url + "/" + path);
+      }
+    });
   };
 
   this.buildThumbnailPath = function (original_url) {
@@ -1414,9 +1439,9 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.renderFiles = function (files) {
-    var _props3 = _this6.props,
-        config = _props3.config,
-        attributes = _props3.attributes;
+    var _props4 = _this6.props,
+        config = _props4.config,
+        attributes = _props4.attributes;
     var render_uploaded_as = attributes.render_uploaded_as;
 
     var isSortable = _this6.state.uploadQueue.length === 0 && attributes.sortable;
@@ -1441,7 +1466,7 @@ var _initialiseProps = function _initialiseProps() {
         maxHeight: attributes.max_height,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1066
+          lineNumber: 1086
         },
         __self: _this6
       },


### PR DESCRIPTION
This allows multi upload fields to be configured with a custom path builder, so that client applications can provide their own logic for building file upload paths (and can thus do things like change the host, or return a CDN-backed version of the asset).

Example usage can be seen in this commit: https://github.com/icelab/als/pull/147/commits/02a09c46de53eb98211e8aaa8bb391f1e9af56ad

Any changes you'd recommend at all here @makenosound?