### PR TITLE
Add initial attributes endpoint support

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -33,6 +33,7 @@ import Sortable from "../../ui/sortable";
 import { hasImageFormatType, sortArrayByOrder, generateUniqueID, noOp, filterUniqueObjects, sanitiseFileName } from "./utils";
 import extractComponent from "../../../utils/extract-component";
 import parseRegexFromString from "../../../utils/parse-regex-from-string";
+import request from "superagent";
 
 /**
  * The default template for uploaded items
@@ -107,7 +108,7 @@ var DefaultRenderTemplate = function (_React$Component) {
         "div",
         { className: styles.listItem, __source: {
             fileName: _jsxFileName,
-            lineNumber: 83
+            lineNumber: 84
           },
           __self: this
         },
@@ -115,7 +116,7 @@ var DefaultRenderTemplate = function (_React$Component) {
           "div",
           { className: styles.listItem__body, __source: {
               fileName: _jsxFileName,
-              lineNumber: 84
+              lineNumber: 85
             },
             __self: this
           },
@@ -123,7 +124,7 @@ var DefaultRenderTemplate = function (_React$Component) {
             "div",
             { className: styles.align_middle, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 85
+                lineNumber: 86
               },
               __self: this
             },
@@ -131,13 +132,13 @@ var DefaultRenderTemplate = function (_React$Component) {
               "div",
               { className: styles.listItem__img, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 87
+                  lineNumber: 88
                 },
                 __self: this
               },
               React.createElement("img", { src: thumbnailUrl, alt: fileName, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 88
+                  lineNumber: 89
                 },
                 __self: this
               })
@@ -146,7 +147,7 @@ var DefaultRenderTemplate = function (_React$Component) {
               "div",
               { className: styles.listItem__title, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 91
+                  lineNumber: 92
                 },
                 __self: this
               },
@@ -154,7 +155,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                 "a",
                 { target: "_blank", href: originalUrl, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 92
+                    lineNumber: 93
                   },
                   __self: this
                 },
@@ -165,7 +166,7 @@ var DefaultRenderTemplate = function (_React$Component) {
               "div",
               { className: styles.copyUrl, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 97
+                  lineNumber: 98
                 },
                 __self: this
               },
@@ -179,7 +180,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                 readOnly: true,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 98
+                  lineNumber: 99
                 },
                 __self: this
               }),
@@ -195,7 +196,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                   },
                   __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 105
+                    lineNumber: 106
                   },
                   __self: this
                 },
@@ -203,7 +204,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                   "span",
                   { className: styles.copyUrlButtonText, __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 112
+                      lineNumber: 113
                     },
                     __self: this
                   },
@@ -213,7 +214,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                   "svg",
                   { width: "15", height: "16", xmlns: "http://www.w3.org/2000/svg", __source: {
                       fileName: _jsxFileName,
-                      lineNumber: 113
+                      lineNumber: 114
                     },
                     __self: this
                   },
@@ -222,7 +223,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                     {
                       __source: {
                         fileName: _jsxFileName,
-                        lineNumber: 114
+                        lineNumber: 115
                       },
                       __self: this
                     },
@@ -232,7 +233,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                     "g",
                     { fill: "none", __source: {
                         fileName: _jsxFileName,
-                        lineNumber: 115
+                        lineNumber: 116
                       },
                       __self: this
                     },
@@ -245,7 +246,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                       className: styles.copyIconPrimary,
                       __source: {
                         fileName: _jsxFileName,
-                        lineNumber: 116
+                        lineNumber: 117
                       },
                       __self: this
                     }),
@@ -256,7 +257,7 @@ var DefaultRenderTemplate = function (_React$Component) {
                       className: styles.copyIconSecondary,
                       __source: {
                         fileName: _jsxFileName,
-                        lineNumber: 124
+                        lineNumber: 125
                       },
                       __self: this
                     })
@@ -434,6 +435,17 @@ var MultiUploadField = function (_React$Component2) {
      */
 
     /**
+     * fetchInitialUploadAttributes
+     *
+     * Allows client applications to provide an endpoint for applying
+     * transformations on the file attributes. For example to change
+     * hosts or use CDN-backed assets.
+     *
+     * @param  {object} a file attributes object
+     * @return {promise}
+     */
+
+    /**
      * onUpdate
      * If `multiple` return the array of file(s), otherwise just the first
      * normalise each fileObject, returning its fileAttributes object
@@ -590,10 +602,6 @@ var MultiUploadField = function (_React$Component2) {
      * Split the path before it's file name.
      * Replace 'upload' with 'view' in the url amd return the string
      *
-     * Checks for a custom configured path builder and returns that
-     * path builder's output when present. The custom builder must
-     * return a promise.
-     *
      * @param {string} url
      * @param {string} path
      * @param {string} dimension: 'original', '50x', '100x100', '400x100', etc
@@ -631,7 +639,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 982
+          lineNumber: 1008
         },
         __self: this
       });
@@ -729,7 +737,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1118
+            lineNumber: 1144
           },
           __self: this
         },
@@ -738,7 +746,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1123
+              lineNumber: 1149
             },
             __self: this
           },
@@ -747,13 +755,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1124
+                lineNumber: 1150
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1125
+                lineNumber: 1151
               },
               __self: this
             })
@@ -770,7 +778,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1133
+                lineNumber: 1159
               },
               __self: this
             },
@@ -778,7 +786,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1142
+              lineNumber: 1168
             },
             __self: this
           }) : null
@@ -803,8 +811,8 @@ MultiUploadField.propTypes = {
     permitted_file_type_regex: PropTypes.string,
     presign_url: PropTypes.string,
     presign_options: PropTypes.object,
+    initial_attributes_url: PropTypes.string,
     render_uploaded_as: PropTypes.string,
-    path_builder: PropTypes.string,
     upload_action_label: PropTypes.string,
     upload_prompt: PropTypes.string
   }),
@@ -902,15 +910,15 @@ var _initialiseProps = function _initialiseProps() {
       copy.fileAttributes[key] = response[key];
     }
 
-    // Build the path. We use a promise so that applications
-    // can provide their own path builder.
-    _this6.buildPath(upload_url, response.path).then(function (path) {
-      // apply the 'original_url' to existing `fileAttributes`
-      copy.fileAttributes["original_url"] = path;
+    // apply the 'original_url' to existing `fileAttributes`
+    copy.fileAttributes["original_url"] = _this6.buildPath(upload_url, response.path);
 
-      if (hasImageFormatType(copy.fileAttributes["file_name"])) {
-        copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
-      }
+    if (hasImageFormatType(copy.fileAttributes["file_name"])) {
+      copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
+    }
+
+    _this6.fetchInitialUploadAttributes(copy.fileAttributes).then(function (initialFileAttributes) {
+      copy.fileAttributes = initialFileAttributes;
 
       var files = _this6.state.files.slice(0);
       var indexOfFile = files.findIndex(function (file) {
@@ -924,8 +932,39 @@ var _initialiseProps = function _initialiseProps() {
 
       _this6.onUpdate(files);
     }).catch(function (error) {
-      console.log(error);
+      console.error(error);
     });
+  };
+
+  this.fetchInitialUploadAttributes = function (originalFileAttributes) {
+    var _props3 = _this6.props,
+        config = _props3.config,
+        attributes = _props3.attributes;
+    var initial_attributes_url = attributes.initial_attributes_url;
+
+    var _ref2 = _this6.context.globalConfig || {},
+        csrfToken = _ref2.csrfToken;
+
+    // Either send the file attributes to the custom endpoint,
+    // or return the attributes unaltered.
+
+
+    if (initial_attributes_url) {
+      return new Promise(function (resolve, reject) {
+        request.post(initial_attributes_url).send(originalFileAttributes).set({
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken
+        }).end(function (err, res) {
+          if (err) return reject({ error: err, message: err.message });
+          resolve(res.body);
+        });
+      });
+    } else {
+      return new Promise(function (resolve, reject) {
+        resolve(originalFileAttributes);
+      });
+    }
   };
 
   this.onUpdate = function (files) {
@@ -1161,7 +1200,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 760
+          lineNumber: 800
         },
         __self: _this6
       },
@@ -1170,7 +1209,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 762
+            lineNumber: 802
           },
           __self: _this6
         },
@@ -1178,7 +1217,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 763
+              lineNumber: 803
             },
             __self: _this6
           },
@@ -1192,7 +1231,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 764
+              lineNumber: 804
             },
             __self: _this6
           },
@@ -1207,7 +1246,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 785
+          lineNumber: 825
         },
         __self: _this6
       },
@@ -1225,7 +1264,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 804
+          lineNumber: 844
         },
         __self: _this6
       },
@@ -1234,7 +1273,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 805
+            lineNumber: 845
           },
           __self: _this6
         },
@@ -1246,7 +1285,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 806
+            lineNumber: 846
           },
           __self: _this6
         },
@@ -1254,7 +1293,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 807
+              lineNumber: 847
             },
             __self: _this6
           },
@@ -1268,7 +1307,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 808
+              lineNumber: 848
             },
             __self: _this6
           },
@@ -1283,7 +1322,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 829
+          lineNumber: 869
         },
         __self: _this6
       },
@@ -1296,7 +1335,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 846
+        lineNumber: 886
       },
       __self: _this6
     });
@@ -1315,7 +1354,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 873
+          lineNumber: 913
         },
         __self: _this6
       },
@@ -1323,7 +1362,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 874
+            lineNumber: 914
           },
           __self: _this6
         },
@@ -1333,7 +1372,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 875
+            lineNumber: 915
           },
           __self: _this6
         },
@@ -1361,7 +1400,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 902
+          lineNumber: 942
         },
         __self: _this6
       },
@@ -1369,7 +1408,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 903
+            lineNumber: 943
           },
           __self: _this6
         },
@@ -1381,36 +1420,24 @@ var _initialiseProps = function _initialiseProps() {
 
   this.buildPath = function (url, path) {
     var dimension = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "original";
-    var _props3 = _this6.props,
-        config = _props3.config,
-        attributes = _props3.attributes;
-    var path_builder = attributes.path_builder;
 
-    // Any custom path builder must return a promise
+    var _ref3 = _this6.context.globalConfig || {},
+        uploader = _ref3.uploader;
 
-    if (_this6.customComponentExists(config, path_builder)) {
-      return extractComponent(config.components, path_builder)(url, path, dimension);
+    if (uploader === "attache") {
+      var pattern = /([^/]*)$/;
+      var splitPath = path.split(pattern);
+      return url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1];
+    } else {
+      return url + "/" + path;
     }
-
-    return new Promise(function (resolve, reject) {
-      var _ref2 = _this6.context.globalConfig || {},
-          uploader = _ref2.uploader;
-
-      if (uploader === "attache") {
-        var pattern = /([^/]*)$/;
-        var splitPath = path.split(pattern);
-        resolve(url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1]);
-      } else {
-        resolve(url + "/" + path);
-      }
-    });
   };
 
   this.buildThumbnailPath = function (original_url) {
     var dimension = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "50x";
 
-    var _ref3 = _this6.context.globalConfig || {},
-        uploader = _ref3.uploader;
+    var _ref4 = _this6.context.globalConfig || {},
+        uploader = _ref4.uploader;
 
     if (uploader === "attache") {
       return original_url.replace("original", dimension);
@@ -1466,7 +1493,7 @@ var _initialiseProps = function _initialiseProps() {
         maxHeight: attributes.max_height,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1086
+          lineNumber: 1112
         },
         __self: _this6
       },

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -589,6 +589,11 @@ var MultiUploadField = function (_React$Component2) {
      * Take a url, path and and optional size (defaults to 'original')
      * Split the path before it's file name.
      * Replace 'upload' with 'view' in the url amd return the string
+     *
+     * Checks for a custom configured path builder and returns that
+     * path builder's output when present. The custom builder must
+     * return a promise.
+     *
      * @param {string} url
      * @param {string} path
      * @param {string} dimension: 'original', '50x', '100x100', '400x100', etc
@@ -626,7 +631,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 962
+          lineNumber: 982
         },
         __self: this
       });
@@ -724,7 +729,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1098
+            lineNumber: 1118
           },
           __self: this
         },
@@ -733,7 +738,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1103
+              lineNumber: 1123
             },
             __self: this
           },
@@ -742,13 +747,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1104
+                lineNumber: 1124
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1105
+                lineNumber: 1125
               },
               __self: this
             })
@@ -765,7 +770,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1113
+                lineNumber: 1133
               },
               __self: this
             },
@@ -773,7 +778,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1122
+              lineNumber: 1142
             },
             __self: this
           }) : null
@@ -799,6 +804,7 @@ MultiUploadField.propTypes = {
     presign_url: PropTypes.string,
     presign_options: PropTypes.object,
     render_uploaded_as: PropTypes.string,
+    path_builder: PropTypes.string,
     upload_action_label: PropTypes.string,
     upload_prompt: PropTypes.string
   }),
@@ -896,23 +902,30 @@ var _initialiseProps = function _initialiseProps() {
       copy.fileAttributes[key] = response[key];
     }
 
-    // apply the 'original_url' to existing `fileAttributes`
-    copy.fileAttributes["original_url"] = _this6.buildPath(upload_url, response.path);
-    if (hasImageFormatType(copy.fileAttributes["file_name"])) {
-      copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
-    }
+    // Build the path. We use a promise so that applications
+    // can provide their own path builder.
+    _this6.buildPath(upload_url, response.path).then(function (path) {
+      // apply the 'original_url' to existing `fileAttributes`
+      copy.fileAttributes["original_url"] = path;
 
-    var files = _this6.state.files.slice(0);
-    var indexOfFile = files.findIndex(function (file) {
-      return file.uid === fileObject.uid;
+      if (hasImageFormatType(copy.fileAttributes["file_name"])) {
+        copy.fileAttributes["thumbnail_url"] = fileObject.file.preview;
+      }
+
+      var files = _this6.state.files.slice(0);
+      var indexOfFile = files.findIndex(function (file) {
+        return file.uid === fileObject.uid;
+      });
+      files.splice(indexOfFile, 1, copy);
+
+      _this6.setState({
+        files: files
+      });
+
+      _this6.onUpdate(files);
+    }).catch(function (error) {
+      console.log(error);
     });
-    files.splice(indexOfFile, 1, copy);
-
-    _this6.setState({
-      files: files
-    });
-
-    _this6.onUpdate(files);
   };
 
   this.onUpdate = function (files) {
@@ -1148,7 +1161,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 755
+          lineNumber: 760
         },
         __self: _this6
       },
@@ -1157,7 +1170,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 757
+            lineNumber: 762
           },
           __self: _this6
         },
@@ -1165,7 +1178,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 758
+              lineNumber: 763
             },
             __self: _this6
           },
@@ -1179,7 +1192,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 759
+              lineNumber: 764
             },
             __self: _this6
           },
@@ -1194,7 +1207,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 780
+          lineNumber: 785
         },
         __self: _this6
       },
@@ -1212,7 +1225,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 799
+          lineNumber: 804
         },
         __self: _this6
       },
@@ -1221,7 +1234,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 800
+            lineNumber: 805
           },
           __self: _this6
         },
@@ -1233,7 +1246,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 801
+            lineNumber: 806
           },
           __self: _this6
         },
@@ -1241,7 +1254,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 802
+              lineNumber: 807
             },
             __self: _this6
           },
@@ -1255,7 +1268,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 803
+              lineNumber: 808
             },
             __self: _this6
           },
@@ -1270,7 +1283,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 824
+          lineNumber: 829
         },
         __self: _this6
       },
@@ -1283,7 +1296,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 841
+        lineNumber: 846
       },
       __self: _this6
     });
@@ -1302,7 +1315,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 868
+          lineNumber: 873
         },
         __self: _this6
       },
@@ -1310,7 +1323,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 869
+            lineNumber: 874
           },
           __self: _this6
         },
@@ -1320,7 +1333,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 870
+            lineNumber: 875
           },
           __self: _this6
         },
@@ -1348,7 +1361,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 897
+          lineNumber: 902
         },
         __self: _this6
       },
@@ -1356,7 +1369,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 898
+            lineNumber: 903
           },
           __self: _this6
         },
@@ -1368,17 +1381,29 @@ var _initialiseProps = function _initialiseProps() {
 
   this.buildPath = function (url, path) {
     var dimension = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "original";
+    var _props3 = _this6.props,
+        config = _props3.config,
+        attributes = _props3.attributes;
+    var path_builder = attributes.path_builder;
 
-    var _ref2 = _this6.context.globalConfig || {},
-        uploader = _ref2.uploader;
+    // Any custom path builder must return a promise
 
-    if (uploader === "attache") {
-      var pattern = /([^/]*)$/;
-      var splitPath = path.split(pattern);
-      return url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1];
-    } else {
-      return url + "/" + path;
+    if (_this6.customComponentExists(config, path_builder)) {
+      return extractComponent(config.components, path_builder)(url, path, dimension);
     }
+
+    return new Promise(function (resolve, reject) {
+      var _ref2 = _this6.context.globalConfig || {},
+          uploader = _ref2.uploader;
+
+      if (uploader === "attache") {
+        var pattern = /([^/]*)$/;
+        var splitPath = path.split(pattern);
+        resolve(url.replace("/upload", "/view") + "/" + splitPath[0] + dimension + "/" + splitPath[1]);
+      } else {
+        resolve(url + "/" + path);
+      }
+    });
   };
 
   this.buildThumbnailPath = function (original_url) {
@@ -1414,9 +1439,9 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.renderFiles = function (files) {
-    var _props3 = _this6.props,
-        config = _props3.config,
-        attributes = _props3.attributes;
+    var _props4 = _this6.props,
+        config = _props4.config,
+        attributes = _props4.attributes;
     var render_uploaded_as = attributes.render_uploaded_as;
 
     var isSortable = _this6.state.uploadQueue.length === 0 && attributes.sortable;
@@ -1441,7 +1466,7 @@ var _initialiseProps = function _initialiseProps() {
         maxHeight: attributes.max_height,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1066
+          lineNumber: 1086
         },
         __self: _this6
       },

--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -601,7 +601,6 @@ var MultiUploadField = function (_React$Component2) {
      * Take a url, path and and optional size (defaults to 'original')
      * Split the path before it's file name.
      * Replace 'upload' with 'view' in the url amd return the string
-     *
      * @param {string} url
      * @param {string} path
      * @param {string} dimension: 'original', '50x', '100x100', '400x100', etc
@@ -639,7 +638,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1008
+          lineNumber: 1007
         },
         __self: this
       });
@@ -737,7 +736,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1144
+            lineNumber: 1143
           },
           __self: this
         },
@@ -746,7 +745,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1149
+              lineNumber: 1148
             },
             __self: this
           },
@@ -755,13 +754,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1150
+                lineNumber: 1149
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1151
+                lineNumber: 1150
               },
               __self: this
             })
@@ -778,7 +777,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1159
+                lineNumber: 1158
               },
               __self: this
             },
@@ -786,7 +785,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1168
+              lineNumber: 1167
             },
             __self: this
           }) : null
@@ -1493,7 +1492,7 @@ var _initialiseProps = function _initialiseProps() {
         maxHeight: attributes.max_height,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1112
+          lineNumber: 1111
         },
         __self: _this6
       },

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -954,7 +954,6 @@ class MultiUploadField extends React.Component {
    * Take a url, path and and optional size (defaults to 'original')
    * Split the path before it's file name.
    * Replace 'upload' with 'view' in the url amd return the string
-   *
    * @param {string} url
    * @param {string} path
    * @param {string} dimension: 'original', '50x', '100x100', '400x100', etc


### PR DESCRIPTION
Allows client applications to provide an endpoint for applying transformations on uploaded file attributes. For example to change hosts or use CDN-backed assets, or to include additional attributes.