### PR TITLE
Add a function for updating search multi selections by id.

### DIFF
--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -95,6 +95,7 @@ var SearchMultiSelectionField = function (_Component) {
     _this2.onChange = _this2.onChange.bind(_this2);
     _this2.onChooseClick = _this2.onChooseClick.bind(_this2);
     _this2.onSelection = _this2.onSelection.bind(_this2);
+    _this2.updateSelection = _this2.updateSelection.bind(_this2);
     _this2.onRemove = _this2.onRemove.bind(_this2);
     _this2.onDrop = _this2.onDrop.bind(_this2);
     _this2.openSelector = _this2.openSelector.bind(_this2);
@@ -263,6 +264,29 @@ var SearchMultiSelectionField = function (_Component) {
     }
 
     /**
+     * Update a particular selection by id.
+     * @return {Null}
+     */
+
+  }, {
+    key: "updateSelection",
+    value: function updateSelection(id, selection) {
+      var value = this.cachedValue;
+      value = value || List();
+
+      // Find the selection's index
+      var index = value.indexOf(id);
+
+      if (index > -1) {
+        var selections = this.cachedSelections.set(index, selection);
+        this.cachedSelections = selections;
+        this.setState({
+          selections: selections
+        });
+      }
+    }
+
+    /**
      * Open the selector popout
      * @return {Null}
      */
@@ -397,7 +421,7 @@ var SearchMultiSelectionField = function (_Component) {
           "data-field-type": "search-multi-selection-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 305
+            lineNumber: 326
           },
           __self: this
         },
@@ -405,13 +429,13 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.header, __source: {
               fileName: _jsxFileName,
-              lineNumber: 310
+              lineNumber: 331
             },
             __self: this
           },
           React.createElement(FieldHeader, { id: name, label: label, hint: hint, error: hasErrors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 311
+              lineNumber: 332
             },
             __self: this
           })
@@ -420,7 +444,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.display, __source: {
               fileName: _jsxFileName,
-              lineNumber: 313
+              lineNumber: 334
             },
             __self: this
           },
@@ -432,7 +456,7 @@ var SearchMultiSelectionField = function (_Component) {
               onClick: this.onChooseClick,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 314
+                lineNumber: 335
               },
               __self: this
             },
@@ -440,7 +464,7 @@ var SearchMultiSelectionField = function (_Component) {
               "div",
               { className: styles.selectionPlaceholder, __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 319
+                  lineNumber: 340
                 },
                 __self: this
               },
@@ -461,7 +485,7 @@ var SearchMultiSelectionField = function (_Component) {
                 testId: "search-multi-selection-field:" + name,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 325
+                  lineNumber: 346
                 },
                 __self: this
               },
@@ -469,7 +493,7 @@ var SearchMultiSelectionField = function (_Component) {
                 "div",
                 { className: styles.openSelectorButton, __source: {
                     fileName: _jsxFileName,
-                    lineNumber: 336
+                    lineNumber: 357
                   },
                   __self: this
                 },
@@ -480,6 +504,7 @@ var SearchMultiSelectionField = function (_Component) {
                   _this4._selector = r;
                 },
                 onSelection: this.onSelection,
+                updateSelection: this.updateSelection,
                 onBlur: this.onSelectorBlur,
                 onFocus: this.onSelectorFocus,
                 onQueryChange: this.onSelectorQueryChange,
@@ -493,7 +518,7 @@ var SearchMultiSelectionField = function (_Component) {
                 url: attributes.search_url,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 339
+                  lineNumber: 360
                 },
                 __self: this
               })
@@ -504,7 +529,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 360
+              lineNumber: 382
             },
             __self: this
           },
@@ -518,7 +543,7 @@ var SearchMultiSelectionField = function (_Component) {
               maxHeight: attributes.max_height,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 361
+                lineNumber: 383
               },
               __self: this
             },
@@ -527,9 +552,10 @@ var SearchMultiSelectionField = function (_Component) {
                 key: index + "_" + option.id,
                 option: option,
                 fetchSelectionsData: _this4.fetchSelectionsData,
+                updateSelection: _this4.updateSelection,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 369
+                  lineNumber: 391
                 },
                 __self: _this4
               });
@@ -538,7 +564,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 378
+            lineNumber: 401
           },
           __self: this
         }) : null

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -65,6 +65,7 @@ class SearchMultiSelectionField extends Component {
     this.onChange = this.onChange.bind(this);
     this.onChooseClick = this.onChooseClick.bind(this);
     this.onSelection = this.onSelection.bind(this);
+    this.updateSelection = this.updateSelection.bind(this);
     this.onRemove = this.onRemove.bind(this);
     this.onDrop = this.onDrop.bind(this);
     this.openSelector = this.openSelector.bind(this);
@@ -195,6 +196,26 @@ class SearchMultiSelectionField extends Component {
     if (attributes.clear_query_on_selection) {
       this.setState({
         selectorQuery: null
+      });
+    }
+  }
+
+  /**
+   * Update a particular selection by id.
+   * @return {Null}
+   */
+  updateSelection(id, selection) {
+    let value = this.cachedValue;
+    value = value || List();
+
+    // Find the selection's index
+    const index = value.indexOf(id);
+
+    if (index > -1) {
+      const selections = this.cachedSelections.set(index, selection);
+      this.cachedSelections = selections;
+      this.setState({
+        selections
       });
     }
   }
@@ -341,6 +362,7 @@ class SearchMultiSelectionField extends Component {
                   this._selector = r;
                 }}
                 onSelection={this.onSelection}
+                updateSelection={this.updateSelection}
                 onBlur={this.onSelectorBlur}
                 onFocus={this.onSelectorFocus}
                 onQueryChange={this.onSelectorQueryChange}
@@ -370,6 +392,7 @@ class SearchMultiSelectionField extends Component {
                   key={`${index}_${option.id}`}
                   option={option}
                   fetchSelectionsData={this.fetchSelectionsData}
+                  updateSelection={this.updateSelection}
                 />
               ))}
             </Sortable>


### PR DESCRIPTION
This adds an `updateSelection` function to search multi selections which allows clients to update the representation of individual selections. This is because the selection may have changed due to external events. Previously, we handed this by refetching all selection data using `fetchSelectionsData` but this broke due to API changes [here](https://github.com/icelab/formalist-standard-react/commit/4df909a1524434f09d143d3e0d12b6396b59278c) where ids now need to be passed. Adding `updateSelection` is more fine grained. Client code can now look like this (for example where a track has been edited via a modal:

```javascript
function onEditSuccess(data) {
  updateSelection(data.id, { id: data.id, label: data.label });
}
```

@makenosound any thoughts on this approach?
 
