### PR TITLE
IE11 compatibility / calendar style fixes

### DIFF
--- a/lib/components/ui/date-picker/index.js
+++ b/lib/components/ui/date-picker/index.js
@@ -2,6 +2,8 @@ var _jsxFileName = "src/components/ui/date-picker/index.js";
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -156,34 +158,24 @@ var DatePicker = function (_React$Component) {
             },
             __self: this
           }),
-          React.createElement(
-            "div",
-            { className: styles.daypickerContainer, __source: {
-                fileName: _jsxFileName,
-                lineNumber: 131
-              },
-              __self: this
+          React.createElement(DayPicker, {
+            ref: function ref(c) {
+              _this2._daypicker = c;
             },
-            React.createElement(DayPicker, {
-              ref: function ref(c) {
-                _this2._daypicker = c;
-              },
-              locale: "en-AU",
-              localeUtils: localeUtils,
-              initialMonth: month,
-              modifiers: {
-                selected: function selected(day) {
-                  return DateUtils.isSameDay(selectedDay, day);
-                }
-              },
-              onDayClick: this.onDayClick,
-              __source: {
-                fileName: _jsxFileName,
-                lineNumber: 132
-              },
-              __self: this
-            })
-          )
+            classNames: styles,
+            locale: "en-AU",
+            localeUtils: localeUtils,
+            initialMonth: month,
+            modifiers: _defineProperty({}, "" + styles.selected, function undefined(day) {
+              return DateUtils.isSameDay(selectedDay, day);
+            }),
+            onDayClick: this.onDayClick,
+            __source: {
+              fileName: _jsxFileName,
+              lineNumber: 131
+            },
+            __self: this
+          })
         )
       );
     }

--- a/lib/components/ui/date-picker/styles.js
+++ b/lib/components/ui/date-picker/styles.js
@@ -1,13 +1,56 @@
 import uid from "uid";
-import { injectGlobal } from "emotion";
+import { css } from "emotion";
 import { colours, typography } from "../styles";
 
-/* Day picker */
-
-export var daypickerContainer = uid(10); // Empty placeholder class
-
 /**
- * Base on the template from https://github.com/gpbl/react-day-picker/blob/master/src/style.css
+ * Based on the template from
+ * https://github.com/gpbl/react-day-picker/blob/master/src/style.css
  */
 
-injectGlobal(".", daypickerContainer, " &{.DayPicker{display:flex;flex-wrap:wrap;justify-content:center;padding:1rem;position:relative;user-select:none;}.DayPicker:focus{outline:none;}.DayPicker-Month{display:table;border-collapse:collapse;border-spacing:0;user-select:none;}.DayPicker-NavBar{position:absolute;left:0;right:0;}.DayPicker-NavButton{position:absolute;width:1.5rem;height:1.5rem;background-repeat:no-repeat;background-position:center;background-size:contain;cursor:pointer;}.DayPicker-NavButton--prev{left:1rem;background-image:url(\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K\");}.DayPicker-NavButton--next{right:1rem;background-image:url(\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=\");}.DayPicker-Caption{display:table-caption;font-weight:", typography.fonts.weights.sansBold, ";margin-bottom:0.8rem;text-align:center;}.DayPicker-Weekdays{display:table-header-group;margin-bottom:0.8rem;}.DayPicker-WeekdaysRow{display:table-row;font-size:0.85em;}.DayPicker-Weekday{color:", colours.values.greyLight, ";display:table-cell;padding:.5rem;text-align:center;}.DayPicker-Body{display:table-row-group;}.DayPicker-Week{display:table-row;}.DayPicker-Day{cursor:pointer;display:table-cell;font-size:0.85em;padding:.5rem;text-align:center;vertical-align:middle;}.DayPicker-Day:hover{text-decoration:underline;}.DayPicker--interactionDisabled,.DayPicker-Day{cursor:default;}/* Default modifiers */\n\n    .DayPicker-Day--today{color:", colours.values.highlight, ";font-weight:500;}.DayPicker-Day--disabled{cursor:default;color:", colours.values.greyLight, ";}.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside){color:", colours.values.white, ";background-color:", colours.values.highlight, ";border-radius:2px;}}");
+// Empty placeholder class as emotion won't generate one if we have no styles
+export var container = uid(10);
+
+export var wrapper = /*#__PURE__*/css("display:flex;flex-wrap:wrap;justify-content:center;padding:1rem;position:relative;user-select:none;&:focus{outline:none;}");
+
+export var interactionDisabled = /*#__PURE__*/css("cursor:default;");
+
+export var navBar = /*#__PURE__*/css("position:absolute;left:0;right:0;");
+
+var navButton = /*#__PURE__*/css("position:absolute;width:1.5rem;height:1.5rem;background-repeat:no-repeat;background-position:center;background-size:contain;cursor:pointer;");
+
+export var navButtonPrev = /*#__PURE__*/css(navButton, ";left:1rem;background-image:url(\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K\");");
+
+export var navButtonNext = /*#__PURE__*/css(navButton, ";right:1rem;background-image:url(\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=\");");
+
+export var navButtonInteractionDisabled = /*#__PURE__*/css();
+
+export var months = /*#__PURE__*/css();
+
+export var month = /*#__PURE__*/css("display:table;border-collapse:collapse;border-spacing:0;user-select:none;");
+
+export var caption = /*#__PURE__*/css(typography.sansBold, ";display:table-caption;margin-bottom:0.8rem;text-align:center;");
+
+export var weekdays = /*#__PURE__*/css("display:table-header-group;margin-bottom:0.8rem;");
+
+export var weekdaysRow = /*#__PURE__*/css("display:table-row;font-size:0.85em;");
+
+export var weekday = /*#__PURE__*/css(colours.greyLightColor, ";display:table-cell;padding:0.5rem;text-align:center;");
+
+export var body = /*#__PURE__*/css("display:table-row-group;");
+
+export var week = /*#__PURE__*/css("display:table-row;");
+
+export var day = /*#__PURE__*/css("cursor:pointer;display:table-cell;font-size:0.85em;padding:0.5rem;text-align:center;vertical-align:middle;&:hover,&:focus{text-decoration:underline;}");
+
+export var footer = uid(10);
+
+export var todayButton = uid(10);
+
+// Default modifiers
+export var today = /*#__PURE__*/css(colours.highlightColor, ";font-weight:500;");
+
+export var selected = /*#__PURE__*/css(colours.whiteColor, ";", colours.highlightBackground, ";border-radius:2px;");
+
+export var disabled = /*#__PURE__*/css(colours.greyLightColor, ";background-color:transparent;cursor:default;");
+
+export var outside = /*#__PURE__*/css(colours.primaryColor, ";background-color:transparent;");

--- a/lib/components/ui/popout/index.js
+++ b/lib/components/ui/popout/index.js
@@ -70,8 +70,8 @@ var Popout = function (_React$Component) {
       var placement = _this.props.placement;
 
       var referencePosition = referenceEl.getBoundingClientRect();
-      var scrollX = window.scrollX;
-      var scrollY = window.scrollY;
+      var scrollX = window.pageXOffset;
+      var scrollY = window.pageYOffset;
       var horzOffset = _this.props.offset.horz;
       var vertOffset = _this.props.offset.vert;
       if (placement === "left") {

--- a/lib/components/ui/popunder/index.js
+++ b/lib/components/ui/popunder/index.js
@@ -62,8 +62,8 @@ var Popunder = function (_React$Component) {
         return;
       }
       var referencePosition = _this._reference.getBoundingClientRect();
-      var scrollX = window.scrollX;
-      var scrollY = window.scrollY;
+      var scrollX = window.pageXOffset;
+      var scrollY = window.pageYOffset;
       var position = {
         left: referencePosition.left + scrollX + _this.props.offset.left,
         top: referencePosition.top + scrollY + referencePosition.height + _this.props.offset.top

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/styles.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/block-items/styles.js
@@ -1,7 +1,7 @@
 import { css } from "emotion";
 import { colours, typography } from "../../../styles";
 
-export var container = /*#__PURE__*/css(colours.greyLightBorder, ";border-style:solid;border-right-width:1px;margin-right:-1px;flex:1;");
+export var container = /*#__PURE__*/css(colours.greyLightBorder, ";border-style:solid;border-right-width:1px;margin-right:-1px;flex:1;flex-basis:auto;");
 
 export var list = /*#__PURE__*/css("padding-top:0.8em;padding-bottom:0.8em;");
 

--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/form-items/styles.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/form-items/styles.js
@@ -1,7 +1,7 @@
 import { css } from "emotion";
 import { colours, typography } from "../../../styles";
 
-export var container = /*#__PURE__*/css(colours.greyLightBorder, ";border-style:solid;border-left-width:1px;flex:1;");
+export var container = /*#__PURE__*/css(colours.greyLightBorder, ";border-style:solid;border-left-width:1px;flex:1;flex-basis:auto;");
 
 export var list = /*#__PURE__*/css("padding-top:0.8em;padding-bottom:0.8em;");
 

--- a/src/components/ui/date-picker/index.js
+++ b/src/components/ui/date-picker/index.js
@@ -128,20 +128,19 @@ class DatePicker extends React.Component {
             onFocus={this.onInputFocus}
             data-field-input="date"
           />
-          <div className={styles.daypickerContainer}>
-            <DayPicker
-              ref={c => {
-                this._daypicker = c;
-              }}
-              locale="en-AU"
-              localeUtils={localeUtils}
-              initialMonth={month}
-              modifiers={{
-                selected: day => DateUtils.isSameDay(selectedDay, day)
-              }}
-              onDayClick={this.onDayClick}
-            />
-          </div>
+          <DayPicker
+            ref={c => {
+              this._daypicker = c;
+            }}
+            classNames={styles}
+            locale="en-AU"
+            localeUtils={localeUtils}
+            initialMonth={month}
+            modifiers={{
+              [`${styles.selected}`]: day => DateUtils.isSameDay(selectedDay, day)
+            }}
+            onDayClick={this.onDayClick}
+          />
         </Popunder>
       </div>
     );

--- a/src/components/ui/date-picker/styles.js
+++ b/src/components/ui/date-picker/styles.js
@@ -1,126 +1,138 @@
 import uid from "uid";
-import { injectGlobal } from "emotion";
+import { css } from "emotion";
 import { colours, typography } from "../styles";
 
-/* Day picker */
-
-export const daypickerContainer = uid(10); // Empty placeholder class
-
 /**
- * Base on the template from https://github.com/gpbl/react-day-picker/blob/master/src/style.css
+ * Based on the template from
+ * https://github.com/gpbl/react-day-picker/blob/master/src/style.css
  */
 
-injectGlobal`
-  .${daypickerContainer} & {
-    .DayPicker {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      padding: 1rem;
-      position: relative;
-      user-select: none;
-    }
-    .DayPicker:focus {
-      outline: none;
-    }
+// Empty placeholder class as emotion won't generate one if we have no styles
+export const container = uid(10);
 
-    .DayPicker-Month {
-      display: table;
-      border-collapse: collapse;
-      border-spacing: 0;
-      user-select: none;
-    }
-
-    .DayPicker-NavBar {
-      position: absolute;
-      left: 0;
-      right: 0;
-    }
-
-    .DayPicker-NavButton {
-      position: absolute;
-      width: 1.5rem;
-      height: 1.5rem;
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: contain;
-      cursor: pointer;
-    }
-
-    .DayPicker-NavButton--prev {
-      left: 1rem;
-      background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K");
-    }
-
-    .DayPicker-NavButton--next {
-      right: 1rem;
-      background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");
-    }
-
-    .DayPicker-Caption {
-      display: table-caption;
-      font-weight: ${typography.fonts.weights.sansBold};
-      margin-bottom: 0.8rem;
-      text-align: center;
-    }
-
-    .DayPicker-Weekdays {
-      display: table-header-group;
-      margin-bottom: 0.8rem;
-    }
-
-    .DayPicker-WeekdaysRow {
-      display: table-row;
-      font-size: 0.85em;
-    }
-
-    .DayPicker-Weekday {
-      color: ${colours.values.greyLight};
-      display: table-cell;
-      padding: .5rem;
-      text-align: center;
-    }
-
-    .DayPicker-Body {
-      display: table-row-group;
-    }
-
-    .DayPicker-Week {
-      display: table-row;
-    }
-
-    .DayPicker-Day {
-      cursor: pointer;
-      display: table-cell;
-      font-size: 0.85em;
-      padding: .5rem;
-      text-align: center;
-      vertical-align: middle;
-    }
-    .DayPicker-Day:hover {
-      text-decoration: underline;
-    }
-
-    .DayPicker--interactionDisabled,
-    .DayPicker-Day {
-      cursor: default;
-    }
-
-    /* Default modifiers */
-
-    .DayPicker-Day--today {
-      color: ${colours.values.highlight};
-      font-weight: 500;
-    }
-
-    .DayPicker-Day--disabled {
-      cursor: default;
-      color: ${colours.values.greyLight};
-    }
-    .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-      color: ${colours.values.white};
-      background-color: ${colours.values.highlight};
-      border-radius: 2px;
-    }
+export const wrapper = css`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 1rem;
+  position: relative;
+  user-select: none;
+  &:focus {
+    outline: none;
   }
+`;
+
+export const interactionDisabled = css`
+  cursor: default;
+`;
+
+export const navBar = css`
+  position: absolute;
+  left: 0;
+  right: 0;
+`;
+
+const navButton = css`
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  cursor: pointer;
+`;
+
+export const navButtonPrev = css`
+  ${navButton};
+  left: 1rem;
+  background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K");
+`;
+
+export const navButtonNext = css`
+  ${navButton};
+  right: 1rem;
+  background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");
+`;
+
+export const navButtonInteractionDisabled = css``;
+
+export const months = css``;
+
+export const month = css`
+  display: table;
+  border-collapse: collapse;
+  border-spacing: 0;
+  user-select: none;
+`;
+
+export const caption = css`
+  ${typography.sansBold};
+  display: table-caption;
+  margin-bottom: 0.8rem;
+  text-align: center;
+`;
+
+export const weekdays = css`
+  display: table-header-group;
+  margin-bottom: 0.8rem;
+`;
+
+export const weekdaysRow = css`
+  display: table-row;
+  font-size: 0.85em;
+`;
+
+export const weekday = css`
+  ${colours.greyLightColor};
+  display: table-cell;
+  padding: 0.5rem;
+  text-align: center;
+`;
+
+export const body = css`
+  display: table-row-group;
+`;
+
+export const week = css`
+  display: table-row;
+`;
+
+export const day = css`
+  cursor: pointer;
+  display: table-cell;
+  font-size: 0.85em;
+  padding: 0.5rem;
+  text-align: center;
+  vertical-align: middle;
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+`;
+
+export const footer = uid(10);
+
+export const todayButton = uid(10);
+
+// Default modifiers
+export const today = css`
+  ${colours.highlightColor};
+  font-weight: 500;
+`;
+
+export const selected = css`
+  ${colours.whiteColor};
+  ${colours.highlightBackground};
+  border-radius: 2px;
+`;
+
+export const disabled = css`
+  ${colours.greyLightColor};
+  background-color: transparent;
+  cursor: default;
+`;
+
+export const outside = css`
+  ${colours.primaryColor};
+  background-color: transparent;
 `;

--- a/src/components/ui/popout/index.js
+++ b/src/components/ui/popout/index.js
@@ -109,8 +109,8 @@ class Popout extends React.Component {
     let position;
     const { placement } = this.props;
     const referencePosition = referenceEl.getBoundingClientRect();
-    const scrollX = window.scrollX;
-    const scrollY = window.scrollY;
+    const scrollX = window.pageXOffset;
+    const scrollY = window.pageYOffset;
     let horzOffset = this.props.offset.horz;
     let vertOffset = this.props.offset.vert;
     if (placement === "left") {

--- a/src/components/ui/popunder/index.js
+++ b/src/components/ui/popunder/index.js
@@ -92,8 +92,8 @@ class Popunder extends React.Component {
       return;
     }
     const referencePosition = this._reference.getBoundingClientRect();
-    const scrollX = window.scrollX;
-    const scrollY = window.scrollY;
+    const scrollX = window.pageXOffset;
+    const scrollY = window.pageYOffset;
     let position = {
       left: referencePosition.left + scrollX + this.props.offset.left,
       top:

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/block-items/styles.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/block-items/styles.js
@@ -7,6 +7,7 @@ export const container = css`
   border-right-width: 1px;
   margin-right: -1px;
   flex: 1;
+  flex-basis: auto;
 `;
 
 export const list = css`

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/form-items/styles.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/form-items/styles.js
@@ -6,6 +6,7 @@ export const container = css`
   border-style: solid;
   border-left-width: 1px;
   flex: 1;
+  flex-basis: auto;
 `;
 
 export const list = css`


### PR DESCRIPTION
Fixes a few small bugs:

* Accessing `scrollX/Y` properties in IE11 (which does not support them)
* Collapsing flex box layouts in IE11
* Calendar styles not applying occasionally

The calendar style bug is hard to replicate, so hard to tell if this is a definite fix. The thinking though is that it the lack of styles appeared to be caused by using `injectGlobal` and so switching to Emotion’s module-style should hopefully skirt around whatever inconsistency is there.