### PR TITLE
Guard against _daypicker being null.

### DIFF
--- a/lib/components/ui/date-picker/index.js
+++ b/lib/components/ui/date-picker/index.js
@@ -82,7 +82,9 @@ var DatePicker = function (_React$Component) {
         }, _this.showCurrentDate);
       }
     }, _this.showCurrentDate = function () {
-      _this._daypicker.showMonth(_this.state.month);
+      if (_this._daypicker) {
+        _this._daypicker.showMonth(_this.state.month);
+      }
     }, _this.onInputFocus = function (e) {
       _this._popunder.openPopunder();
     }, _this.onDayClick = function (day) {
@@ -126,7 +128,7 @@ var DatePicker = function (_React$Component) {
         "div",
         { className: className, __source: {
             fileName: _jsxFileName,
-            lineNumber: 114
+            lineNumber: 116
           },
           __self: this
         },
@@ -140,7 +142,7 @@ var DatePicker = function (_React$Component) {
             closeOnOutsideClick: true,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 115
+              lineNumber: 117
             },
             __self: this
           },
@@ -154,7 +156,7 @@ var DatePicker = function (_React$Component) {
             "data-field-input": "date",
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 122
+              lineNumber: 124
             },
             __self: this
           }),
@@ -172,7 +174,7 @@ var DatePicker = function (_React$Component) {
             onDayClick: this.onDayClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 131
+              lineNumber: 133
             },
             __self: this
           })

--- a/src/components/ui/date-picker/index.js
+++ b/src/components/ui/date-picker/index.js
@@ -87,7 +87,9 @@ class DatePicker extends React.Component {
   };
 
   showCurrentDate = () => {
-    this._daypicker.showMonth(this.state.month);
+    if (this._daypicker) {
+      this._daypicker.showMonth(this.state.month);
+    }
   };
 
   onInputFocus = e => {


### PR DESCRIPTION
Thanks to how ref works, the _daypicker value here can sometimes be null. This prevents calling functions on it if so.

https://github.com/facebook/react/issues/5131